### PR TITLE
201976 Update create project error handling and region

### DIFF
--- a/src/Api/Dfe.Complete.Api.Client/Generated/swagger.json
+++ b/src/Api/Dfe.Complete.Api.Client/Generated/swagger.json
@@ -526,7 +526,8 @@
             "type": "string"
           },
           "groupReferenceNumber": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "handingOverToRegionalCaseworkService": {
             "type": "boolean"

--- a/src/Core/Dfe.Complete.Application/ApplicationServiceCollectionExtensions.cs
+++ b/src/Core/Dfe.Complete.Application/ApplicationServiceCollectionExtensions.cs
@@ -19,12 +19,20 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddApplicationDependencyGroup(
             this IServiceCollection services, IConfiguration config)
         {
+            //services.AddSingleton(serviceProvider =>
+            //{
+            //    var runtimeConfig = serviceProvider.GetRequiredService<IConfiguration>();
+            //    return runtimeConfig;
+            //});
+
             var performanceLoggingEnabled = config.GetValue<bool>("Features:PerformanceLoggingEnabled");
 
             services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly());
 
             services.AddAcademiesApiClient<ITrustsV4Client, TrustsV4Client>(config);
             services.AddAcademiesApiClient<IEstablishmentsV4Client, EstablishmentsV4Client>(config);
+
+            var baseUrl = config.GetValue<string>("AcademiesApiClient:BaseUrl");
 
             services.AddMediatR(cfg =>
             {

--- a/src/Core/Dfe.Complete.Application/Projects/Commands/CreateProject/CreateConversionProject.cs
+++ b/src/Core/Dfe.Complete.Application/Projects/Commands/CreateProject/CreateConversionProject.cs
@@ -48,8 +48,9 @@ namespace Dfe.Complete.Application.Projects.Commands.CreateProject
             Region? region;
             try
             {
-                region = (await establishmentsClient.GetEstablishmentByUrnAsync(request.Urn.Value.ToString(),
-                    cancellationToken)).Gor?.Code?.ToEnumFromChar<Region>();
+                var establishment = await establishmentsClient.GetEstablishmentByUrnAsync(request.Urn.Value.ToString(),
+                    cancellationToken);
+                region = establishment.Gor?.Code?.ToEnumFromChar<Region>();
             }
             catch (AcademiesApiException e)
             {

--- a/src/Core/Dfe.Complete.Application/Projects/Commands/CreateProject/CreateConversionProject.cs
+++ b/src/Core/Dfe.Complete.Application/Projects/Commands/CreateProject/CreateConversionProject.cs
@@ -82,13 +82,12 @@ namespace Dfe.Complete.Application.Projects.Commands.CreateProject
                 // The user Team should be moved as a Claim or Group to the Entra (MS AD)
                 var userRequest = await sender.Send(new GetUserByAdIdQuery(request.UserAdId), cancellationToken);
 
-                if (userRequest is not { IsSuccess: true } || userRequest.Value is null)
-                    throw new NotFoundException("No user found.", innerException: new Exception(userRequest.Error ?? "No user found."));
+                if (!userRequest.IsSuccess)
+                    throw new NotFoundException("No user found.", innerException: new Exception(userRequest.Error));
+                projectUser = userRequest.Value ?? throw new NotFoundException("No user found.");
 
-                projectUser = userRequest.Value;
-
-                var projectUserTeam = projectUser?.Team;
-                var projectUserId = projectUser?.Id;
+                var projectUserTeam = projectUser.Team;
+                var projectUserId = projectUser.Id;
 
                 team = projectUserTeam.FromDescription<ProjectTeam>();
                 assignedAt = DateTime.UtcNow;

--- a/src/Core/Dfe.Complete.Application/Projects/Commands/CreateProject/CreateMatConversionProject.cs
+++ b/src/Core/Dfe.Complete.Application/Projects/Commands/CreateProject/CreateMatConversionProject.cs
@@ -68,13 +68,11 @@ public record CreateMatConversionProjectCommand(
                 // The user Team should be moved as a Claim or Group to the Entra (MS AD)
                 var userRequest = await sender.Send(new GetUserByAdIdQuery(request.UserAdId), cancellationToken);
 
-                if (userRequest is not { IsSuccess: true } || userRequest.Value is null)
-                    throw new NotFoundException("No user found.", innerException: new Exception(userRequest.Error ?? "No user found."));
-
-                projectUser = userRequest.Value;
-
-                var projectUserTeam = projectUser?.Team;
-                var projectUserId = projectUser?.Id;
+                if (!userRequest.IsSuccess)
+                    throw new NotFoundException("No user found.", innerException: new Exception(userRequest.Error));
+                projectUser = userRequest.Value ?? throw new NotFoundException("No user found.");
+                var projectUserTeam = projectUser.Team;
+                var projectUserId = projectUser.Id;
 
                 team = projectUserTeam.FromDescription<ProjectTeam>();
                 assignedAt = DateTime.UtcNow;

--- a/src/Core/Dfe.Complete.Application/Projects/Commands/CreateProject/CreateMatTransferProject.cs
+++ b/src/Core/Dfe.Complete.Application/Projects/Commands/CreateProject/CreateMatTransferProject.cs
@@ -73,10 +73,9 @@ public class CreateMatTransferProjectCommandHandler(
                 // The user Team should be moved as a Claim or Group to the Entra (MS AD)
                 var userRequest = await sender.Send(new GetUserByAdIdQuery(request.UserAdId), cancellationToken);
 
-                if (!userRequest.IsSuccess || userRequest.Value == null)
+                if (!userRequest.IsSuccess)
                     throw new NotFoundException("No user found.", innerException: new Exception(userRequest.Error));
-            
-                projectUser = userRequest.Value;
+                projectUser = userRequest.Value ?? throw new NotFoundException("No user found.");
 
                 var projectUserTeam = projectUser.Team;
                 var projectUserId = projectUser.Id;

--- a/src/Core/Dfe.Complete.Application/Projects/Commands/CreateProject/CreateMatTransferProject.cs
+++ b/src/Core/Dfe.Complete.Application/Projects/Commands/CreateProject/CreateMatTransferProject.cs
@@ -97,7 +97,7 @@ public class CreateMatTransferProjectCommandHandler(
                     tasksDataId,
                     region,
                     team,
-                    projectUser.Id,
+                    projectUser?.Id,
                     projectUserAssignedToId,
                     assignedAt,
                     request.EstablishmentSharepointLink,

--- a/src/Core/Dfe.Complete.Application/Projects/Commands/CreateProject/CreateTransferProject.cs
+++ b/src/Core/Dfe.Complete.Application/Projects/Commands/CreateProject/CreateTransferProject.cs
@@ -87,13 +87,12 @@ public class CreateTransferProjectCommandHandler(
                         "Project cannot be unassigned if it is not being handed over to Regional Case Worker Services");
                 var userRequest = await sender.Send(new GetUserByAdIdQuery(request.UserAdId), cancellationToken);
 
-                if (userRequest is not { IsSuccess: true } || userRequest.Value is null)
+                if (!userRequest.IsSuccess)
                     throw new NotFoundException("No user found.", innerException: new Exception(userRequest.Error));
+                projectUser = userRequest.Value ?? throw new NotFoundException("No user found.");
 
-                projectUser = userRequest.Value;
-
-                var projectUserTeam = projectUser?.Team;
-                var projectUserId = projectUser?.Id;
+                var projectUserTeam = projectUser.Team;
+                var projectUserId = projectUser.Id;
 
                 team = projectUserTeam.FromDescription<ProjectTeam>();
                 assignedAt = DateTime.UtcNow;

--- a/src/Core/Dfe.Complete.Utils/EnumExtensions.cs
+++ b/src/Core/Dfe.Complete.Utils/EnumExtensions.cs
@@ -10,6 +10,11 @@ public static class EnumExtensions
 	{
 		return enumValue.HasValue ? ((char)Convert.ToUInt16(enumValue.Value)).ToString() : string.Empty;
 	}
+	
+	public static string GetCharValue<TEnum>(this TEnum enumValue) where TEnum : struct, Enum
+	{
+		return ((char)Convert.ToUInt16(enumValue)).ToString();
+	}
 		
 	public static string ToDescription<T>(this T source)
 	{

--- a/src/Tests/Dfe.Complete.Api.Tests.Integration/Controllers/ProjectsControllerTests.cs
+++ b/src/Tests/Dfe.Complete.Api.Tests.Integration/Controllers/ProjectsControllerTests.cs
@@ -50,13 +50,16 @@ public class ProjectsControllerTests
         dbContext.Users.Update(testUser);
         dbContext.ProjectGroups.Update(group);
 
-        var establishmentDto = fixture.Customize(new AcademiesApiEstablishmentDtoCustomisation())
+        var gor = fixture.Customize(new NameAndCodeDtoCustomisation()).Create<NameAndCodeDto>();
+
+        var establishmentDto = fixture.Customize(new AcademiesApiEstablishmentDtoCustomisation(){Gor = gor})
             .Create<EstablishmentDto>();
 
         var localAuthority = await dbContext.LocalAuthorities.FirstOrDefaultAsync();
         var establishment = fixture.Customize(new EstablishmentsCustomization
         {
-            Urn = new Domain.ValueObjects.Urn(int.Parse(establishmentDto.Urn)), LocalAuthorityCode = localAuthority.Code
+            Urn = new Domain.ValueObjects.Urn(int.Parse(establishmentDto.Urn)), 
+            LocalAuthorityCode = localAuthority.Code
         }).Create<GiasEstablishment>();
         await dbContext.GiasEstablishments.AddAsync(establishment);
 

--- a/src/Tests/Dfe.Complete.Api.Tests.Integration/Controllers/ProjectsControllerTests.cs
+++ b/src/Tests/Dfe.Complete.Api.Tests.Integration/Controllers/ProjectsControllerTests.cs
@@ -13,6 +13,8 @@ using DfE.CoreLibs.Testing.AutoFixture.Attributes;
 using DfE.CoreLibs.Testing.AutoFixture.Customizations;
 using DfE.CoreLibs.Testing.Mocks.WebApplicationFactory;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Project = Dfe.Complete.Domain.Entities.Project;
 
 namespace Dfe.Complete.Api.Tests.Integration.Controllers;
@@ -35,6 +37,9 @@ public class ProjectsControllerTests
         IProjectsClient projectsClient,
         IFixture fixture)
     {
+
+        var runtimeConfig = factory.Services.GetRequiredService<IConfiguration>();
+
         factory.TestClaims = [new Claim(ClaimTypes.Role, WriteRole), new Claim(ClaimTypes.Role, ReadRole)];
 
         var dbContext = factory.GetDbContext<CompleteContext>();

--- a/src/Tests/Dfe.Complete.Api.Tests.Integration/Controllers/UsersControllerTests.cs
+++ b/src/Tests/Dfe.Complete.Api.Tests.Integration/Controllers/UsersControllerTests.cs
@@ -8,6 +8,7 @@ using DfE.CoreLibs.Testing.AutoFixture.Attributes;
 using DfE.CoreLibs.Testing.Mocks.WebApplicationFactory;
 using Microsoft.EntityFrameworkCore;
 using Project = Dfe.Complete.Domain.Entities.Project;
+using Urn = Dfe.Complete.Domain.ValueObjects.Urn;
 
 namespace Dfe.Complete.Api.Tests.Integration.Controllers;
 
@@ -109,9 +110,16 @@ public class UsersControllerTests
         testUser.LastName = "Warms";
         dbContext.Users.Update(testUser);
 
-        var localAuthorityId = dbContext.LocalAuthorities.FirstOrDefault().Id;
+        var localAuthorityId = (await dbContext.LocalAuthorities.FirstOrDefaultAsync())?.Id!;
+
         
         var establishments = fixture.CreateMany<GiasEstablishment>(50).ToList();
+        int urn = 100000;
+        foreach (var establishment in establishments)
+        {
+            establishment.Urn = new Urn(urn);
+            urn++;
+        }
         await dbContext.GiasEstablishments.AddRangeAsync(establishments);
         var projects = establishments.Select(establishment =>
         {

--- a/src/Tests/Dfe.Complete.Api.Tests.Integration/Customizations/CustomWebApplicationDbApiContextFactoryCustomization.cs
+++ b/src/Tests/Dfe.Complete.Api.Tests.Integration/Customizations/CustomWebApplicationDbApiContextFactoryCustomization.cs
@@ -1,0 +1,87 @@
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using AutoFixture;
+using Dfe.Complete.Api.Client.Extensions;
+using Dfe.Complete.Api.Tests.Integration.Factories;
+using Dfe.Complete.Application.Common.Mappers;
+using Dfe.Complete.Client;
+using Dfe.Complete.Client.Contracts;
+using Dfe.Complete.Infrastructure.Database;
+using Dfe.Complete.Tests.Common.Seeders;
+using DfE.CoreLibs.Testing.Mocks.Authentication;
+using DfE.CoreLibs.Testing.Mocks.WebApplicationFactory;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Dfe.Complete.Api.Tests.Integration.Customizations
+{
+    public class CustomWebApplicationDbApiContextFactoryCustomization : ICustomization
+    {
+        public void Customize(IFixture fixture)
+        {
+            fixture.Customize<CustomWebApplicationDbApiContextFactory<Program>>(composer => composer.FromFactory(() =>
+            {
+                var factory = new CustomWebApplicationDbApiContextFactory<Program>
+                {
+                    SeedData = new Dictionary<Type, Action<DbContext>>
+                    {
+                        { typeof(CompleteContext), context => CompleteContextSeeder.Seed((CompleteContext)context, fixture) }
+                        // { typeof(CompleteContext), context => {} },
+                    },
+                    ExternalServicesConfiguration = services =>
+                    {
+                        services.PostConfigure<AuthenticationOptions>(options =>
+                        {
+                            options.DefaultAuthenticateScheme = "TestScheme";
+                            options.DefaultChallengeScheme = "TestScheme";
+                        });
+
+                        services.AddAuthentication("TestScheme")
+                            .AddScheme<AuthenticationSchemeOptions, MockJwtBearerHandler>("TestScheme", options => { });
+
+                        services.AddAutoMapper(cfg =>
+                        {
+                            cfg.AddProfile<AutoMapping>();
+                        });
+                    },
+                    ExternalHttpClientConfiguration = client =>
+                    {
+                        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "external-mock-token");
+                    },
+                    MockApiServer = default!
+                };
+
+                var client = factory.CreateClient();
+                var apiUrl = factory.MockApiServer.Url;
+
+                var config = new ConfigurationBuilder()
+                    .AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        { "CompleteApiClient:BaseUrl", client.BaseAddress!.ToString() },
+                        { "AcademiesApiClient:BaseUrl", apiUrl}
+                    })
+                    .Build();
+
+                var services = new ServiceCollection();
+                services.AddSingleton<IConfiguration>(config);
+                
+                services.AddCompleteApiClient<IProjectsClient, ProjectsClient>(config, client);
+                services.AddCompleteApiClient<ICsvExportClient, CsvExportClient>(config, client);
+                services.AddCompleteApiClient<IUsersClient, UsersClient>(config, client);
+                var serviceProvider = services.BuildServiceProvider();
+                
+                fixture.Inject(factory);
+                fixture.Inject(serviceProvider);
+                fixture.Inject(client);
+                fixture.Inject(serviceProvider.GetRequiredService<IProjectsClient>());
+                fixture.Inject(serviceProvider.GetRequiredService<ICsvExportClient>());
+                fixture.Inject(serviceProvider.GetRequiredService<IUsersClient>());
+                fixture.Inject(new List<Claim>());
+
+                return factory;
+            }).Without(factory => factory.MockApiServer));
+        }
+    }
+}

--- a/src/Tests/Dfe.Complete.Api.Tests.Integration/Customizations/CustomWebApplicationDbApiContextFactoryCustomization.cs
+++ b/src/Tests/Dfe.Complete.Api.Tests.Integration/Customizations/CustomWebApplicationDbApiContextFactoryCustomization.cs
@@ -1,6 +1,8 @@
 using System.Net.Http.Headers;
 using System.Security.Claims;
 using AutoFixture;
+using Dfe.AcademiesApi.Client;
+using Dfe.AcademiesApi.Client.Contracts;
 using Dfe.Complete.Api.Client.Extensions;
 using Dfe.Complete.Api.Tests.Integration.Factories;
 using Dfe.Complete.Application.Common.Mappers;
@@ -9,7 +11,7 @@ using Dfe.Complete.Client.Contracts;
 using Dfe.Complete.Infrastructure.Database;
 using Dfe.Complete.Tests.Common.Seeders;
 using DfE.CoreLibs.Testing.Mocks.Authentication;
-using DfE.CoreLibs.Testing.Mocks.WebApplicationFactory;
+using Dfe.TramsDataApi.Client.Extensions;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -70,6 +72,7 @@ namespace Dfe.Complete.Api.Tests.Integration.Customizations
                 services.AddCompleteApiClient<IProjectsClient, ProjectsClient>(config, client);
                 services.AddCompleteApiClient<ICsvExportClient, CsvExportClient>(config, client);
                 services.AddCompleteApiClient<IUsersClient, UsersClient>(config, client);
+                services.AddAcademiesApiClient<IEstablishmentsV4Client, EstablishmentsV4Client>(config, client);
                 var serviceProvider = services.BuildServiceProvider();
                 
                 fixture.Inject(factory);
@@ -78,6 +81,7 @@ namespace Dfe.Complete.Api.Tests.Integration.Customizations
                 fixture.Inject(serviceProvider.GetRequiredService<IProjectsClient>());
                 fixture.Inject(serviceProvider.GetRequiredService<ICsvExportClient>());
                 fixture.Inject(serviceProvider.GetRequiredService<IUsersClient>());
+                fixture.Inject(serviceProvider.GetRequiredService<IEstablishmentsV4Client>());
                 fixture.Inject(new List<Claim>());
 
                 return factory;

--- a/src/Tests/Dfe.Complete.Api.Tests.Integration/Dfe.Complete.Api.Tests.Integration.csproj
+++ b/src/Tests/Dfe.Complete.Api.Tests.Integration/Dfe.Complete.Api.Tests.Integration.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.13" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.13" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.13" />
+    <PackageReference Include="WireMock.Net" Version="1.7.4" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Tests/Dfe.Complete.Api.Tests.Integration/Factories/CustomWebApplicationDbApiContextFactory.cs
+++ b/src/Tests/Dfe.Complete.Api.Tests.Integration/Factories/CustomWebApplicationDbApiContextFactory.cs
@@ -1,0 +1,150 @@
+﻿using System.Collections.Specialized;
+using DfE.CoreLibs.Testing.Mocks.WebApplicationFactory;
+using Newtonsoft.Json;
+using WireMock.Logging;
+using WireMock.Matchers;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+using WireMock.Util;
+using Xunit.Abstractions;
+
+namespace Dfe.Complete.Api.Tests.Integration.Factories;
+
+public class CustomWebApplicationDbApiContextFactory<TProgram> : CustomWebApplicationDbContextFactory<TProgram> where TProgram : class
+{
+   private static int _currentPort = 5080;
+   private static readonly object Sync = new();
+
+   public WireMockServer MockApiServer { get; set; }
+
+   protected override void ConfigureClient(HttpClient client)
+   {
+      int port = AllocateNext();
+      MockApiServer = WireMockServer.Start(port);
+      MockApiServer.LogEntriesChanged += EntriesChanged;
+      base.ConfigureClient(client);
+   }
+
+   public ITestOutputHelper DebugOutput { get; set; }
+
+
+   public IReadOnlyList<ILogEntry> GetMockServerLogs(string path, HttpMethod verb = null)
+   {
+      IRequestBuilder requestBuilder = Request.Create().WithPath(path);
+      if (verb is not null) requestBuilder.UsingMethod(verb.Method);
+      return MockApiServer.FindLogEntries(requestBuilder);
+   }
+
+   private void EntriesChanged(object sender, NotifyCollectionChangedEventArgs e)
+   {
+      DebugOutput.WriteLine($"API Server change: {JsonConvert.SerializeObject(e)}");
+   }
+
+   public void AddGetWithJsonResponse<TResponseBody>(string path, TResponseBody responseBody)
+   {
+      MockApiServer
+         .Given(Request.Create()
+            .WithPath(path)
+            .UsingGet())
+         .RespondWith(Response.Create()
+            .WithStatusCode(200)
+            .WithHeader("Content-Type", "application/json")
+            .WithBody(JsonConvert.SerializeObject(responseBody)));
+   }
+
+   public void AddPatchWithJsonRequest<TRequestBody, TResponseBody>(string path, TRequestBody requestBody, TResponseBody responseBody)
+   {
+      MockApiServer
+         .Given(Request.Create()
+            .WithPath(path)
+            .WithBody(new JsonMatcher(JsonConvert.SerializeObject(requestBody), true))
+            .UsingPatch())
+         .RespondWith(Response.Create()
+            .WithStatusCode(200)
+            .WithHeader("Content-Type", "application/json")
+            .WithBody(JsonConvert.SerializeObject(responseBody)));
+   }
+
+   public void AddApiCallWithBodyDelegate<TResponseBody>(string path, Func<IBodyData, bool> bodyDelegate, TResponseBody responseBody, HttpMethod verb = null)
+   {
+      MockApiServer
+         .Given(Request.Create()
+            .WithPath(path)
+            .WithBody(bodyDelegate)
+            .UsingMethod(verb == null ? HttpMethod.Post.ToString() : verb.ToString()))
+         .RespondWith(Response.Create()
+            .WithStatusCode(200)
+            .WithHeader("Content-Type", "application/json")
+            .WithBody(JsonConvert.SerializeObject(responseBody)));
+   }
+
+   public void AddPutWithJsonRequest<TRequestBody, TResponseBody>(string path, TRequestBody requestBody, TResponseBody responseBody)
+   {
+      MockApiServer
+         .Given(Request.Create()
+            .WithPath(path)
+            .WithBody(new JsonMatcher(JsonConvert.SerializeObject(requestBody), true))
+            .UsingPut())
+         .RespondWith(Response.Create()
+            .WithStatusCode(200)
+            .WithHeader("Content-Type", "application/json")
+            .WithBody(JsonConvert.SerializeObject(responseBody)));
+   }
+
+   public void AddPostWithJsonRequest<TRequestBody, TResponseBody>(string path, TRequestBody requestBody, TResponseBody responseBody)
+   {
+      MockApiServer
+         .Given(Request.Create()
+            .WithPath(path)
+            .WithBody(new JsonMatcher(JsonConvert.SerializeObject(requestBody), true))
+            .UsingPost())
+         .RespondWith(Response.Create()
+            .WithStatusCode(200)
+            .WithHeader("Content-Type", "application/json")
+            .WithBody(JsonConvert.SerializeObject(responseBody)));
+   }
+
+   public void AddAnyPostWithJsonRequest<TResponseBody>(string path, TResponseBody responseBody)
+   {
+      MockApiServer
+         .Given(Request.Create()
+            .WithPath(path)
+            .UsingPost())
+         .RespondWith(Response.Create()
+            .WithStatusCode(200)
+            .WithHeader("Content-Type", "application/json")
+            .WithBody(JsonConvert.SerializeObject(responseBody)));
+   }
+
+   public void AddErrorResponse(string path, string method)
+   {
+      MockApiServer
+         .Given(Request.Create()
+            .WithPath(path)
+            .UsingMethod(method))
+         .RespondWith(Response.Create()
+            .WithStatusCode(500));
+   }
+
+   public void Reset()
+   {
+      MockApiServer.Reset();
+   }
+
+   private static int AllocateNext()
+   {
+      lock (Sync)
+      {
+         int next = _currentPort;
+         _currentPort++;
+         return next;
+      }
+   }
+
+   public new void Dispose()
+   {
+      MockApiServer.Stop();
+      base.Dispose();
+   }
+}

--- a/src/Tests/Dfe.Complete.Application.Tests/CommandHandlers/Project/CreateConversionProjectCommandHandlerTests.cs
+++ b/src/Tests/Dfe.Complete.Application.Tests/CommandHandlers/Project/CreateConversionProjectCommandHandlerTests.cs
@@ -421,4 +421,62 @@ public class CreateConversionProjectCommandHandlerTests
         Assert.NotNull(projectId);
         Assert.Null(capturedProject.GroupId);
     }
+        [Theory]
+        [CustomAutoData(typeof(DateOnlyCustomization), typeof(IgnoreVirtualMembersCustomisation))]
+        public async Task Handle_ShouldThrowNotFoundException_WhenUserIdIsNull(
+            [Frozen] ICompleteRepository<Domain.Entities.Project> mockProjectRepository,
+            [Frozen] ICompleteRepository<ConversionTasksData> mockConversionTaskRepository,
+            [Frozen] Mock<ISender> mockSender,
+            CreateConversionProjectCommand command)
+        {
+            // Arrange
+            var handler = new CreateConversionProjectCommandHandler(
+                mockProjectRepository,
+                mockConversionTaskRepository,
+                mockSender.Object);
+
+            command = command with { UserAdId = null };
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<ArgumentException>(() => handler.Handle(command, default));
+
+            Assert.Equal("UserAdId should not be null", exception.Message);
+            Assert.Null(exception.InnerException);
+            
+            await mockProjectRepository.Received(0).AddAsync(It.IsAny<Domain.Entities.Project>(), It.IsAny<CancellationToken>());
+            await mockConversionTaskRepository.Received(0).AddAsync(It.IsAny<ConversionTasksData>(), It.IsAny<CancellationToken>());
+        }
+        
+        [Theory]
+        [CustomAutoData(typeof(DateOnlyCustomization), typeof(IgnoreVirtualMembersCustomisation))]
+        public async Task Handle_ShouldThrowNotFoundException_WhenUserRequestSuccess_WithNullResponse(
+            [Frozen] ICompleteRepository<Domain.Entities.Project> mockProjectRepository,
+            [Frozen] ICompleteRepository<ConversionTasksData> mockConversionTaskRepository,
+            [Frozen] Mock<ISender> mockSender,
+            CreateConversionProjectCommand command)
+        {
+            // Arrange
+            var handler = new CreateConversionProjectCommandHandler(
+                mockProjectRepository,
+                mockConversionTaskRepository,
+                mockSender.Object);
+
+            mockSender.Setup(s => s.Send(It.IsAny<GetUserByAdIdQuery>(), It.IsAny<CancellationToken>()))!
+                .ReturnsAsync(Result<UserDto>.Success(null!));
+
+            mockSender.Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(
+                    new GetLocalAuthorityBySchoolUrnResponseDto(Guid.NewGuid())));
+
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<NotFoundException>(() => handler.Handle(command, default));
+
+            Assert.Equal("No user found.", exception.Message);
+            Assert.NotNull(exception.InnerException);
+            Assert.Equal("No user found.", exception.InnerException.Message);
+            
+            await mockProjectRepository.Received(0).AddAsync(It.IsAny<Domain.Entities.Project>(), It.IsAny<CancellationToken>());
+            await mockConversionTaskRepository.Received(0).AddAsync(It.IsAny<ConversionTasksData>(), It.IsAny<CancellationToken>());
+        }
+        
 }

--- a/src/Tests/Dfe.Complete.Application.Tests/CommandHandlers/Project/CreateMatConversionProjectCommandHandlerTests.cs
+++ b/src/Tests/Dfe.Complete.Application.Tests/CommandHandlers/Project/CreateMatConversionProjectCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using AutoFixture.Xunit2;
+using Dfe.AcademiesApi.Client.Contracts;
 using DfE.CoreLibs.Testing.AutoFixture.Attributes;
 using DfE.CoreLibs.Testing.AutoFixture.Customizations; 
 using Dfe.Complete.Application.Projects.Commands.CreateProject;
@@ -15,7 +16,6 @@ using Dfe.Complete.Application.Common.Models;
 using Dfe.Complete.Application.Projects.Models;
 using Dfe.Complete.Application.Projects.Queries.GetLocalAuthority;
 using Dfe.Complete.Application.Projects.Queries.GetUser;
-using Dfe.Complete.Tests.Common.Customizations.Models;
 
 namespace Dfe.Complete.Application.Tests.CommandHandlers.Project;
 
@@ -31,7 +31,15 @@ public class CreateMatConversionProjectCommandHandlerTests
     )
     {
         // Arrange
-        var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository, mockSender.Object);
+        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+        var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository,
+            mockEstablishmentClient.Object,
+            mockSender.Object);
+        
         const ProjectTeam userTeam = ProjectTeam.WestMidlands;
         var userDto = new UserDto
         {
@@ -99,7 +107,14 @@ public class CreateMatConversionProjectCommandHandlerTests
     )
     {
         // Arrange
-        var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository, mockSender.Object);
+        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+        var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository,
+            mockEstablishmentClient.Object,
+            mockSender.Object);
 
         command = command with { HandingOverToRegionalCaseworkService = true };
 
@@ -150,8 +165,14 @@ public class CreateMatConversionProjectCommandHandlerTests
     )
     {
         // Arrange
-        var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository, mockSender.Object);
-        command = command with { HandingOverToRegionalCaseworkService = false };
+        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+        var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository,
+            mockEstablishmentClient.Object,
+            mockSender.Object);
 
         const ProjectTeam userTeam = ProjectTeam.WestMidlands;
         var userDto = new UserDto
@@ -205,9 +226,14 @@ public class CreateMatConversionProjectCommandHandlerTests
         mockSender.Setup(s => s.Send(It.IsAny<GetUserByAdIdQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<UserDto?>.Failure("DB ERROR"));
 
-        var handler = new CreateMatConversionProjectCommandHandler(
-            mockProjectRepository,
-            mockConversionTaskRepository,
+        // Arrange
+        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+        var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository,
+            mockEstablishmentClient.Object,
             mockSender.Object);
 
         // Act & Assert
@@ -234,9 +260,14 @@ public class CreateMatConversionProjectCommandHandlerTests
         mockSender.Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Failure(expectedError));
 
-        var handler = new CreateMatConversionProjectCommandHandler(
-            mockProjectRepository,
-            mockConversionTaskRepository,
+        // Arrange
+        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+        var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository,
+            mockEstablishmentClient.Object,
             mockSender.Object);
 
         // Act & Assert
@@ -264,9 +295,14 @@ public class CreateMatConversionProjectCommandHandlerTests
         mockSender.Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(responseDto));
 
-        var handler = new CreateMatConversionProjectCommandHandler(
-            mockProjectRepository,
-            mockConversionTaskRepository,
+        // Arrange
+        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+        var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository,
+            mockEstablishmentClient.Object,
             mockSender.Object);
 
         // Act & Assert
@@ -288,13 +324,17 @@ public class CreateMatConversionProjectCommandHandlerTests
         [Frozen] Mock<ISender> mockSender,
         CreateMatConversionProjectCommand command)
     {
-        var responseDto = new GetLocalAuthorityBySchoolUrnResponseDto(null);
         mockSender.Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(null));
 
-        var handler = new CreateMatConversionProjectCommandHandler(
-            mockProjectRepository,
-            mockConversionTaskRepository,
+        // Arrange
+        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+        var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository,
+            mockEstablishmentClient.Object,
             mockSender.Object);
 
         // Act & Assert
@@ -317,17 +357,24 @@ public class CreateMatConversionProjectCommandHandlerTests
             CreateMatConversionProjectCommand command)
         {
             // Arrange
-            var handler = new CreateMatConversionProjectCommandHandler(
-                mockProjectRepository,
-                mockConversionTaskRepository,
+            var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+            Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+            mockEstablishmentClient.Setup(mock =>
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+            var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository,
+                mockEstablishmentClient.Object,
                 mockSender.Object);
+            
+            mockSender.Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), default))
+                .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(new GetLocalAuthorityBySchoolUrnResponseDto(Guid.NewGuid())));
 
             command = command with { UserAdId = null };
 
             // Act & Assert
             var exception = await Assert.ThrowsAsync<ArgumentException>(() => handler.Handle(command, default));
 
-            Assert.Equal("UserAdId should not be null", exception.Message);
+            Assert.Equal("Project cannot be unassigned if it is not being handed over to Regional Case Worker Services", exception.Message);
             Assert.Null(exception.InnerException);
             
             await mockProjectRepository.Received(0).AddAsync(It.IsAny<Domain.Entities.Project>(), It.IsAny<CancellationToken>());
@@ -343,9 +390,13 @@ public class CreateMatConversionProjectCommandHandlerTests
             CreateMatConversionProjectCommand command)
         {
             // Arrange
-            var handler = new CreateMatConversionProjectCommandHandler(
-                mockProjectRepository,
-                mockConversionTaskRepository,
+            var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+            Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+            mockEstablishmentClient.Setup(mock =>
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+            var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository,
+                mockEstablishmentClient.Object,
                 mockSender.Object);
 
             mockSender.Setup(s => s.Send(It.IsAny<GetUserByAdIdQuery>(), It.IsAny<CancellationToken>()))!
@@ -359,8 +410,7 @@ public class CreateMatConversionProjectCommandHandlerTests
             var exception = await Assert.ThrowsAsync<NotFoundException>(() => handler.Handle(command, default));
 
             Assert.Equal("No user found.", exception.Message);
-            Assert.NotNull(exception.InnerException);
-            Assert.Equal("No user found.", exception.InnerException.Message);
+            Assert.Null(exception.InnerException);
             
             await mockProjectRepository.Received(0).AddAsync(It.IsAny<Domain.Entities.Project>(), It.IsAny<CancellationToken>());
             await mockConversionTaskRepository.Received(0).AddAsync(It.IsAny<ConversionTasksData>(), It.IsAny<CancellationToken>());

--- a/src/Tests/Dfe.Complete.Application.Tests/CommandHandlers/Project/CreateMatConversionProjectCommandHandlerTests.cs
+++ b/src/Tests/Dfe.Complete.Application.Tests/CommandHandlers/Project/CreateMatConversionProjectCommandHandlerTests.cs
@@ -1,13 +1,13 @@
 using AutoFixture.Xunit2;
 using Dfe.AcademiesApi.Client.Contracts;
 using DfE.CoreLibs.Testing.AutoFixture.Attributes;
-using DfE.CoreLibs.Testing.AutoFixture.Customizations; 
+using DfE.CoreLibs.Testing.AutoFixture.Customizations;
 using Dfe.Complete.Application.Projects.Commands.CreateProject;
 using Dfe.Complete.Domain.Entities;
 using Dfe.Complete.Domain.Enums;
 using Dfe.Complete.Domain.Interfaces.Repositories;
 using Dfe.Complete.Domain.ValueObjects;
-using Dfe.Complete.Tests.Common.Customizations.Behaviours; 
+using Dfe.Complete.Tests.Common.Customizations.Behaviours;
 using Dfe.Complete.Utils;
 using NSubstitute;
 using MediatR;
@@ -31,15 +31,17 @@ public class CreateMatConversionProjectCommandHandlerTests
     )
     {
         // Arrange
-        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
         Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
         mockEstablishmentClient.Setup(mock =>
-            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
         var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository,
             mockEstablishmentClient.Object,
             mockSender.Object);
-        
+
         const ProjectTeam userTeam = ProjectTeam.WestMidlands;
         var userDto = new UserDto
         {
@@ -50,10 +52,12 @@ public class CreateMatConversionProjectCommandHandlerTests
         var createdAt = DateTime.UtcNow;
         var conversionTaskId = Guid.NewGuid();
         var conversionTask = new ConversionTasksData(new TaskDataId(conversionTaskId), createdAt, createdAt);
-            
+
         mockSender.Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), default))
-            .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(new GetLocalAuthorityBySchoolUrnResponseDto(Guid.NewGuid())));
-            
+            .ReturnsAsync(
+                Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(
+                    new GetLocalAuthorityBySchoolUrnResponseDto(Guid.NewGuid())));
+
         mockSender
             .Setup(sender => sender.Send(It.IsAny<GetUserByAdIdQuery>(), default))
             .ReturnsAsync(Result<UserDto?>.Success(userDto));
@@ -92,7 +96,7 @@ public class CreateMatConversionProjectCommandHandlerTests
         Assert.Equal(command.EstablishmentSharepointLink, capturedProject.EstablishmentSharepointLink);
         Assert.Equal(command.IncomingTrustSharepointLink, capturedProject.IncomingTrustSharepointLink);
         Assert.Equal(command.HandoverComments, capturedProject.Notes.FirstOrDefault()?.Body);
-            
+
         Assert.Equal(command.NewTrustName, capturedProject.NewTrustName);
         Assert.Equal(command.NewTrustReferenceNumber, capturedProject.NewTrustReferenceNumber);
     }
@@ -107,11 +111,13 @@ public class CreateMatConversionProjectCommandHandlerTests
     )
     {
         // Arrange
-        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
         Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
         mockEstablishmentClient.Setup(mock =>
-            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
         var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository,
             mockEstablishmentClient.Object,
             mockSender.Object);
@@ -128,10 +134,12 @@ public class CreateMatConversionProjectCommandHandlerTests
         var createdAt = DateTime.UtcNow;
         var conversionTaskId = Guid.NewGuid();
         var conversionTask = new ConversionTasksData(new TaskDataId(conversionTaskId), createdAt, createdAt);
-            
+
         mockSender.Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), default))
-            .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(new GetLocalAuthorityBySchoolUrnResponseDto(Guid.NewGuid())));
-            
+            .ReturnsAsync(
+                Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(
+                    new GetLocalAuthorityBySchoolUrnResponseDto(Guid.NewGuid())));
+
         mockSender
             .Setup(sender => sender.Send(It.IsAny<GetUserByAdIdQuery>(), default))
             .ReturnsAsync(Result<UserDto?>.Success(userDto));
@@ -165,11 +173,13 @@ public class CreateMatConversionProjectCommandHandlerTests
     )
     {
         // Arrange
-        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
         Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
         mockEstablishmentClient.Setup(mock =>
-            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
         var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository,
             mockEstablishmentClient.Object,
             mockSender.Object);
@@ -184,10 +194,12 @@ public class CreateMatConversionProjectCommandHandlerTests
         var createdAt = DateTime.UtcNow;
         var conversionTaskId = Guid.NewGuid();
         var conversionTask = new ConversionTasksData(new TaskDataId(conversionTaskId), createdAt, createdAt);
-            
+
         mockSender.Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), default))
-            .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(new GetLocalAuthorityBySchoolUrnResponseDto(Guid.NewGuid())));
-            
+            .ReturnsAsync(
+                Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(
+                    new GetLocalAuthorityBySchoolUrnResponseDto(Guid.NewGuid())));
+
         mockSender
             .Setup(sender => sender.Send(It.IsAny<GetUserByAdIdQuery>(), default))
             .ReturnsAsync(Result<UserDto?>.Success(userDto));
@@ -210,7 +222,7 @@ public class CreateMatConversionProjectCommandHandlerTests
         Assert.NotNull(capturedProject.AssignedAt);
         Assert.NotNull(capturedProject.AssignedToId);
     }
-    
+
     [Theory]
     [CustomAutoData(typeof(DateOnlyCustomization), typeof(IgnoreVirtualMembersCustomisation))]
     public async Task Handle_ShouldThrowNotFoundException_WhenUserRequestFails(
@@ -227,11 +239,13 @@ public class CreateMatConversionProjectCommandHandlerTests
             .ReturnsAsync(Result<UserDto?>.Failure("DB ERROR"));
 
         // Arrange
-        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
         Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
         mockEstablishmentClient.Setup(mock =>
-            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
         var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository,
             mockEstablishmentClient.Object,
             mockSender.Object);
@@ -241,13 +255,13 @@ public class CreateMatConversionProjectCommandHandlerTests
         Assert.Equal("No user found.", exception.Message);
         Assert.NotNull(exception.InnerException);
         Assert.Equal("DB ERROR", exception.InnerException.Message);
-            
+
         await mockProjectRepository.Received(0)
             .AddAsync(It.IsAny<Domain.Entities.Project>(), It.IsAny<CancellationToken>());
         await mockConversionTaskRepository.Received(0)
             .AddAsync(It.IsAny<ConversionTasksData>(), It.IsAny<CancellationToken>());
     }
-    
+
     [Theory]
     [CustomAutoData(typeof(DateOnlyCustomization), typeof(IgnoreVirtualMembersCustomisation))]
     public async Task Handle_ShouldThrowNotFoundException_WhenLocalAuthorityRequestFails(
@@ -261,28 +275,31 @@ public class CreateMatConversionProjectCommandHandlerTests
             .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Failure(expectedError));
 
         // Arrange
-        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
         Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
         mockEstablishmentClient.Setup(mock =>
-            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
         var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository,
             mockEstablishmentClient.Object,
             mockSender.Object);
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<NotFoundException>(() => handler.Handle(command, default));
-        var expectedMessage = $"No Local authority could be found via Establishments for School Urn: {command.Urn.Value}.";
+        var expectedMessage =
+            $"No Local authority could be found via Establishments for School Urn: {command.Urn.Value}.";
         Assert.Equal(expectedMessage, exception.Message);
         Assert.NotNull(exception.InnerException);
         Assert.Equal(expectedError, exception.InnerException.Message);
-            
+
         await mockProjectRepository.Received(0)
             .AddAsync(It.IsAny<Domain.Entities.Project>(), It.IsAny<CancellationToken>());
         await mockConversionTaskRepository.Received(0)
             .AddAsync(It.IsAny<ConversionTasksData>(), It.IsAny<CancellationToken>());
     }
-    
+
     [Theory]
     [CustomAutoData(typeof(DateOnlyCustomization), typeof(IgnoreVirtualMembersCustomisation))]
     public async Task Handle_ShouldThrowNotFoundException_WhenLocalAuthorityIdIsNull(
@@ -296,26 +313,29 @@ public class CreateMatConversionProjectCommandHandlerTests
             .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(responseDto));
 
         // Arrange
-        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
         Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
         mockEstablishmentClient.Setup(mock =>
-            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
         var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository,
             mockEstablishmentClient.Object,
             mockSender.Object);
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<NotFoundException>(() => handler.Handle(command, default));
-        var expectedMessage = $"No Local authority could be found via Establishments for School Urn: {command.Urn.Value}.";
+        var expectedMessage =
+            $"No Local authority could be found via Establishments for School Urn: {command.Urn.Value}.";
         Assert.Equal(expectedMessage, exception.Message);
-            
+
         await mockProjectRepository.Received(0)
             .AddAsync(It.IsAny<Domain.Entities.Project>(), It.IsAny<CancellationToken>());
         await mockConversionTaskRepository.Received(0)
             .AddAsync(It.IsAny<ConversionTasksData>(), It.IsAny<CancellationToken>());
     }
-    
+
     [Theory]
     [CustomAutoData(typeof(DateOnlyCustomization), typeof(IgnoreVirtualMembersCustomisation))]
     public async Task Handle_ShouldThrowNotFoundException_WhenLocalAuthorityRequestSuccess_WithNullResponse(
@@ -328,91 +348,105 @@ public class CreateMatConversionProjectCommandHandlerTests
             .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(null));
 
         // Arrange
-        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
         Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
         mockEstablishmentClient.Setup(mock =>
-            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
         var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository,
             mockEstablishmentClient.Object,
             mockSender.Object);
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<NotFoundException>(() => handler.Handle(command, default));
-        var expectedMessage = $"No Local authority could be found via Establishments for School Urn: {command.Urn.Value}.";
+        var expectedMessage =
+            $"No Local authority could be found via Establishments for School Urn: {command.Urn.Value}.";
         Assert.Equal(expectedMessage, exception.Message);
-            
+
         await mockProjectRepository.Received(0)
             .AddAsync(It.IsAny<Domain.Entities.Project>(), It.IsAny<CancellationToken>());
         await mockConversionTaskRepository.Received(0)
             .AddAsync(It.IsAny<ConversionTasksData>(), It.IsAny<CancellationToken>());
     }
-    
+
     [Theory]
-        [CustomAutoData(typeof(DateOnlyCustomization), typeof(IgnoreVirtualMembersCustomisation))]
-        public async Task Handle_ShouldThrowNotFoundException_WhenUserIdIsNull(
-            [Frozen] ICompleteRepository<Domain.Entities.Project> mockProjectRepository,
-            [Frozen] ICompleteRepository<ConversionTasksData> mockConversionTaskRepository,
-            [Frozen] Mock<ISender> mockSender,
-            CreateMatConversionProjectCommand command)
-        {
-            // Arrange
-            var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
-            Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
-            mockEstablishmentClient.Setup(mock =>
-                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
-            var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository,
-                mockEstablishmentClient.Object,
-                mockSender.Object);
-            
-            mockSender.Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), default))
-                .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(new GetLocalAuthorityBySchoolUrnResponseDto(Guid.NewGuid())));
+    [CustomAutoData(typeof(DateOnlyCustomization), typeof(IgnoreVirtualMembersCustomisation))]
+    public async Task Handle_ShouldThrowNotFoundException_WhenUserIdIsNull(
+        [Frozen] ICompleteRepository<Domain.Entities.Project> mockProjectRepository,
+        [Frozen] ICompleteRepository<ConversionTasksData> mockConversionTaskRepository,
+        [Frozen] Mock<ISender> mockSender,
+        CreateMatConversionProjectCommand command)
+    {
+        // Arrange
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
 
-            command = command with { UserAdId = null };
+        var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository,
+            mockEstablishmentClient.Object,
+            mockSender.Object);
 
-            // Act & Assert
-            var exception = await Assert.ThrowsAsync<ArgumentException>(() => handler.Handle(command, default));
-
-            Assert.Equal("Project cannot be unassigned if it is not being handed over to Regional Case Worker Services", exception.Message);
-            Assert.Null(exception.InnerException);
-            
-            await mockProjectRepository.Received(0).AddAsync(It.IsAny<Domain.Entities.Project>(), It.IsAny<CancellationToken>());
-            await mockConversionTaskRepository.Received(0).AddAsync(It.IsAny<ConversionTasksData>(), It.IsAny<CancellationToken>());
-        }
-        
-        [Theory]
-        [CustomAutoData(typeof(DateOnlyCustomization), typeof(IgnoreVirtualMembersCustomisation))]
-        public async Task Handle_ShouldThrowNotFoundException_WhenUserRequestSuccess_WithNullResponse(
-            [Frozen] ICompleteRepository<Domain.Entities.Project> mockProjectRepository,
-            [Frozen] ICompleteRepository<ConversionTasksData> mockConversionTaskRepository,
-            [Frozen] Mock<ISender> mockSender,
-            CreateMatConversionProjectCommand command)
-        {
-            // Arrange
-            var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
-            Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
-            mockEstablishmentClient.Setup(mock =>
-                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
-            var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository,
-                mockEstablishmentClient.Object,
-                mockSender.Object);
-
-            mockSender.Setup(s => s.Send(It.IsAny<GetUserByAdIdQuery>(), It.IsAny<CancellationToken>()))!
-                .ReturnsAsync(Result<UserDto>.Success(null!));
-
-            mockSender.Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(
+        mockSender.Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), default))
+            .ReturnsAsync(
+                Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(
                     new GetLocalAuthorityBySchoolUrnResponseDto(Guid.NewGuid())));
 
-            // Act & Assert
-            var exception = await Assert.ThrowsAsync<NotFoundException>(() => handler.Handle(command, default));
+        command = command with { UserAdId = null };
 
-            Assert.Equal("No user found.", exception.Message);
-            Assert.Null(exception.InnerException);
-            
-            await mockProjectRepository.Received(0).AddAsync(It.IsAny<Domain.Entities.Project>(), It.IsAny<CancellationToken>());
-            await mockConversionTaskRepository.Received(0).AddAsync(It.IsAny<ConversionTasksData>(), It.IsAny<CancellationToken>());
-        }
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() => handler.Handle(command, default));
+
+        Assert.Equal("Project cannot be unassigned if it is not being handed over to Regional Case Worker Services",
+            exception.Message);
+        Assert.Null(exception.InnerException);
+
+        await mockProjectRepository.Received(0)
+            .AddAsync(It.IsAny<Domain.Entities.Project>(), It.IsAny<CancellationToken>());
+        await mockConversionTaskRepository.Received(0)
+            .AddAsync(It.IsAny<ConversionTasksData>(), It.IsAny<CancellationToken>());
+    }
+
+    [Theory]
+    [CustomAutoData(typeof(DateOnlyCustomization), typeof(IgnoreVirtualMembersCustomisation))]
+    public async Task Handle_ShouldThrowNotFoundException_WhenUserRequestSuccess_WithNullResponse(
+        [Frozen] ICompleteRepository<Domain.Entities.Project> mockProjectRepository,
+        [Frozen] ICompleteRepository<ConversionTasksData> mockConversionTaskRepository,
+        [Frozen] Mock<ISender> mockSender,
+        CreateMatConversionProjectCommand command)
+    {
+        // Arrange
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
+        var handler = new CreateMatConversionProjectCommandHandler(mockProjectRepository, mockConversionTaskRepository,
+            mockEstablishmentClient.Object,
+            mockSender.Object);
+
+        mockSender.Setup(s => s.Send(It.IsAny<GetUserByAdIdQuery>(), It.IsAny<CancellationToken>()))!
+            .ReturnsAsync(Result<UserDto>.Success(null!));
+
+        mockSender.Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(
+                new GetLocalAuthorityBySchoolUrnResponseDto(Guid.NewGuid())));
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<NotFoundException>(() => handler.Handle(command, default));
+
+        Assert.Equal("No user found.", exception.Message);
+        Assert.Null(exception.InnerException);
+
+        await mockProjectRepository.Received(0)
+            .AddAsync(It.IsAny<Domain.Entities.Project>(), It.IsAny<CancellationToken>());
+        await mockConversionTaskRepository.Received(0)
+            .AddAsync(It.IsAny<ConversionTasksData>(), It.IsAny<CancellationToken>());
+    }
 }

--- a/src/Tests/Dfe.Complete.Application.Tests/CommandHandlers/Project/CreateMatTransferProjectCommandHandlerTests.cs
+++ b/src/Tests/Dfe.Complete.Application.Tests/CommandHandlers/Project/CreateMatTransferProjectCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using AutoFixture.Xunit2;
+using Dfe.AcademiesApi.Client.Contracts;
 using DfE.CoreLibs.Testing.AutoFixture.Attributes;
 using DfE.CoreLibs.Testing.AutoFixture.Customizations;
 using Dfe.Complete.Application.Projects.Commands.CreateProject;
@@ -14,7 +15,6 @@ using Dfe.Complete.Application.Projects.Models;
 using Dfe.Complete.Application.Common.Models;
 using Dfe.Complete.Application.Projects.Queries.GetLocalAuthority;
 using Dfe.Complete.Application.Projects.Queries.GetUser;
-using Dfe.Complete.Tests.Common.Customizations.Models;
 using Dfe.Complete.Domain.Entities;
 
 namespace Dfe.Complete.Application.Tests.CommandHandlers.Project;
@@ -31,7 +31,14 @@ public class CreateMatTransferProjectCommandHandlerTests
     )
     {
         // Arrange
-        var handler = new CreateMatTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository, mockSender.Object);
+        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+        var handler = new CreateMatTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
+            mockEstablishmentClient.Object,
+            mockSender.Object);
 
         const ProjectTeam userTeam = ProjectTeam.WestMidlands;
         var userDto = new UserDto
@@ -99,7 +106,14 @@ public class CreateMatTransferProjectCommandHandlerTests
     )
     {
         // Arrange
-        var handler = new CreateMatTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository, mockSender.Object);
+        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+        var handler = new CreateMatTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
+            mockEstablishmentClient.Object,
+            mockSender.Object);
 
         command = command with { HandingOverToRegionalCaseworkService = true };
 
@@ -150,7 +164,14 @@ public class CreateMatTransferProjectCommandHandlerTests
     )
     {
         // Arrange
-        var handler = new CreateMatTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository, mockSender.Object);
+        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+        var handler = new CreateMatTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
+            mockEstablishmentClient.Object,
+            mockSender.Object);
 
         command = command with { HandingOverToRegionalCaseworkService = false };
 
@@ -200,9 +221,13 @@ public class CreateMatTransferProjectCommandHandlerTests
         CreateMatTransferProjectCommand command)
     {
         // Arrange
-        var handler = new CreateMatTransferProjectCommandHandler(
-            mockProjectRepository,
-            mockTransferTaskRepository,
+        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+        var handler = new CreateMatTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
+            mockEstablishmentClient.Object,
             mockSender.Object);
 
         var expectedErrorMessage = $"No Local authority could be found via Establishments for School Urn: {command.Urn.Value}.";
@@ -232,9 +257,14 @@ public class CreateMatTransferProjectCommandHandlerTests
         CreateMatTransferProjectCommand command)
     {
         // Arrange
-        var handler = new CreateMatTransferProjectCommandHandler(
-            mockProjectRepository,
-            mockTransferTaskRepository,
+        command = command with { HandingOverToRegionalCaseworkService = false};
+        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+        var handler = new CreateMatTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
+            mockEstablishmentClient.Object,
             mockSender.Object);
 
         var expectedErrorMessage = "No user found.";
@@ -267,9 +297,13 @@ public class CreateMatTransferProjectCommandHandlerTests
         CreateMatTransferProjectCommand command)
     {
         // Arrange
-        var handler = new CreateMatTransferProjectCommandHandler(
-            mockProjectRepository,
-            mockTransferTaskRepository,
+        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+        var handler = new CreateMatTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
+            mockEstablishmentClient.Object,
             mockSender.Object);
 
         var expectedErrorMessage = $"No Local authority could be found via Establishments for School Urn: {command.Urn.Value}.";

--- a/src/Tests/Dfe.Complete.Application.Tests/CommandHandlers/Project/CreateMatTransferProjectCommandHandlerTests.cs
+++ b/src/Tests/Dfe.Complete.Application.Tests/CommandHandlers/Project/CreateMatTransferProjectCommandHandlerTests.cs
@@ -31,11 +31,13 @@ public class CreateMatTransferProjectCommandHandlerTests
     )
     {
         // Arrange
-        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
         Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
         mockEstablishmentClient.Setup(mock =>
-            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
         var handler = new CreateMatTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
             mockEstablishmentClient.Object,
             mockSender.Object);
@@ -49,11 +51,14 @@ public class CreateMatTransferProjectCommandHandlerTests
 
         var createdAt = DateTime.UtcNow;
         var transferTaskId = Guid.NewGuid();
-        var transferTask = new TransferTasksData(new TaskDataId(transferTaskId), createdAt, createdAt, command.IsDueToInedaquateOfstedRating, command.IsDueToIssues, command.OutGoingTrustWillClose);
-            
+        var transferTask = new TransferTasksData(new TaskDataId(transferTaskId), createdAt, createdAt,
+            command.IsDueToInedaquateOfstedRating, command.IsDueToIssues, command.OutGoingTrustWillClose);
+
         mockSender.Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), default))
-            .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(new GetLocalAuthorityBySchoolUrnResponseDto(Guid.NewGuid())));
-            
+            .ReturnsAsync(
+                Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(
+                    new GetLocalAuthorityBySchoolUrnResponseDto(Guid.NewGuid())));
+
         mockSender
             .Setup(sender => sender.Send(It.IsAny<GetUserByAdIdQuery>(), default))
             .ReturnsAsync(Result<UserDto?>.Success(userDto));
@@ -91,7 +96,7 @@ public class CreateMatTransferProjectCommandHandlerTests
         Assert.Equal(command.EstablishmentSharepointLink, capturedProject.EstablishmentSharepointLink);
         Assert.Equal(command.IncomingTrustSharepointLink, capturedProject.IncomingTrustSharepointLink);
         Assert.Equal(command.HandoverComments, capturedProject.Notes.FirstOrDefault()?.Body);
-            
+
         Assert.Equal(command.NewTrustName, capturedProject.NewTrustName);
         Assert.Equal(command.NewTrustReferenceNumber, capturedProject.NewTrustReferenceNumber);
     }
@@ -106,11 +111,13 @@ public class CreateMatTransferProjectCommandHandlerTests
     )
     {
         // Arrange
-        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
         Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
         mockEstablishmentClient.Setup(mock =>
-            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
         var handler = new CreateMatTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
             mockEstablishmentClient.Object,
             mockSender.Object);
@@ -126,11 +133,14 @@ public class CreateMatTransferProjectCommandHandlerTests
 
         var createdAt = DateTime.UtcNow;
         var transferTaskId = Guid.NewGuid();
-        var transferTask = new TransferTasksData(new TaskDataId(transferTaskId), createdAt, createdAt, command.IsDueToInedaquateOfstedRating, command.IsDueToIssues, command.OutGoingTrustWillClose);
-            
+        var transferTask = new TransferTasksData(new TaskDataId(transferTaskId), createdAt, createdAt,
+            command.IsDueToInedaquateOfstedRating, command.IsDueToIssues, command.OutGoingTrustWillClose);
+
         mockSender.Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), default))
-            .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(new GetLocalAuthorityBySchoolUrnResponseDto(Guid.NewGuid())));
-            
+            .ReturnsAsync(
+                Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(
+                    new GetLocalAuthorityBySchoolUrnResponseDto(Guid.NewGuid())));
+
         mockSender
             .Setup(sender => sender.Send(It.IsAny<GetUserByAdIdQuery>(), default))
             .ReturnsAsync(Result<UserDto?>.Success(userDto));
@@ -164,11 +174,13 @@ public class CreateMatTransferProjectCommandHandlerTests
     )
     {
         // Arrange
-        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
         Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
         mockEstablishmentClient.Setup(mock =>
-            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
         var handler = new CreateMatTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
             mockEstablishmentClient.Object,
             mockSender.Object);
@@ -184,11 +196,14 @@ public class CreateMatTransferProjectCommandHandlerTests
 
         var createdAt = DateTime.UtcNow;
         var transferTaskId = Guid.NewGuid();
-        var transferTask = new TransferTasksData(new TaskDataId(transferTaskId), createdAt, createdAt, command.IsDueToInedaquateOfstedRating, command.IsDueToIssues, command.OutGoingTrustWillClose);
-            
+        var transferTask = new TransferTasksData(new TaskDataId(transferTaskId), createdAt, createdAt,
+            command.IsDueToInedaquateOfstedRating, command.IsDueToIssues, command.OutGoingTrustWillClose);
+
         mockSender.Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), default))
-            .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(new GetLocalAuthorityBySchoolUrnResponseDto(Guid.NewGuid())));
-            
+            .ReturnsAsync(
+                Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(
+                    new GetLocalAuthorityBySchoolUrnResponseDto(Guid.NewGuid())));
+
         mockSender
             .Setup(sender => sender.Send(It.IsAny<GetUserByAdIdQuery>(), default))
             .ReturnsAsync(Result<UserDto?>.Success(userDto));
@@ -211,7 +226,7 @@ public class CreateMatTransferProjectCommandHandlerTests
         Assert.NotNull(capturedProject.AssignedAt);
         Assert.NotNull(capturedProject.AssignedToId);
     }
-        
+
     [Theory]
     [CustomAutoData(typeof(DateOnlyCustomization), typeof(IgnoreVirtualMembersCustomisation))]
     public async Task Handle_ShouldThrowException_WhenLocalAuthorityRequestFails(
@@ -221,16 +236,19 @@ public class CreateMatTransferProjectCommandHandlerTests
         CreateMatTransferProjectCommand command)
     {
         // Arrange
-        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
         Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
         mockEstablishmentClient.Setup(mock =>
-            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
         var handler = new CreateMatTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
             mockEstablishmentClient.Object,
             mockSender.Object);
 
-        var expectedErrorMessage = $"No Local authority could be found via Establishments for School Urn: {command.Urn.Value}.";
+        var expectedErrorMessage =
+            $"No Local authority could be found via Establishments for School Urn: {command.Urn.Value}.";
 
         mockSender.Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), default))
             .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Failure("Local Authority DB error"));
@@ -247,7 +265,7 @@ public class CreateMatTransferProjectCommandHandlerTests
         Assert.NotNull(exception.InnerException);
         Assert.Equal("Local Authority DB error", exception.InnerException.Message);
     }
-        
+
     [Theory]
     [CustomAutoData(typeof(DateOnlyCustomization), typeof(IgnoreVirtualMembersCustomisation))]
     public async Task Handle_ShouldThrowException_WhenUserRequestFails(
@@ -257,12 +275,14 @@ public class CreateMatTransferProjectCommandHandlerTests
         CreateMatTransferProjectCommand command)
     {
         // Arrange
-        command = command with { HandingOverToRegionalCaseworkService = false};
-        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        command = command with { HandingOverToRegionalCaseworkService = false };
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
         Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
         mockEstablishmentClient.Setup(mock =>
-            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
         var handler = new CreateMatTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
             mockEstablishmentClient.Object,
             mockSender.Object);
@@ -270,7 +290,9 @@ public class CreateMatTransferProjectCommandHandlerTests
         var expectedErrorMessage = "No user found.";
 
         mockSender.Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), default))
-            .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(new GetLocalAuthorityBySchoolUrnResponseDto(Guid.NewGuid())));
+            .ReturnsAsync(
+                Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(
+                    new GetLocalAuthorityBySchoolUrnResponseDto(Guid.NewGuid())));
 
         mockSender.Setup(s => s.Send(It.IsAny<GetUserByAdIdQuery>(), default))
             .ReturnsAsync(Result<UserDto?>.Failure("User DB error"));
@@ -287,7 +309,7 @@ public class CreateMatTransferProjectCommandHandlerTests
         Assert.NotNull(exception.InnerException);
         Assert.Equal("User DB error", exception.InnerException.Message);
     }
-        
+
     [Theory]
     [CustomAutoData(typeof(DateOnlyCustomization), typeof(IgnoreVirtualMembersCustomisation))]
     public async Task Handle_ShouldThrowException_WhenLocalAuthorityRequestReturnsSuccess_WithNullResponse(
@@ -297,16 +319,19 @@ public class CreateMatTransferProjectCommandHandlerTests
         CreateMatTransferProjectCommand command)
     {
         // Arrange
-        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
         Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
         mockEstablishmentClient.Setup(mock =>
-            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
         var handler = new CreateMatTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
             mockEstablishmentClient.Object,
             mockSender.Object);
 
-        var expectedErrorMessage = $"No Local authority could be found via Establishments for School Urn: {command.Urn.Value}.";
+        var expectedErrorMessage =
+            $"No Local authority could be found via Establishments for School Urn: {command.Urn.Value}.";
 
         mockSender.Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), default))
             .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(null));

--- a/src/Tests/Dfe.Complete.Application.Tests/CommandHandlers/Project/CreateTransferProjectCommandHandlerTests.cs
+++ b/src/Tests/Dfe.Complete.Application.Tests/CommandHandlers/Project/CreateTransferProjectCommandHandlerTests.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using AutoFixture.Xunit2;
+using Dfe.AcademiesApi.Client.Contracts;
 using DfE.CoreLibs.Testing.AutoFixture.Attributes;
 using Dfe.Complete.Domain.Interfaces.Repositories;
 using NSubstitute;
@@ -33,9 +34,14 @@ public class CreateTransferProjectCommandHandlerTests
         CreateTransferProjectCommand command)
     {
         // Arrange
-        var handler =
-            new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
-                mockSender.Object);
+        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+        var handler = new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
+            mockEstablishmentClient.Object,
+            mockSender.Object);
 
         const ProjectTeam team = ProjectTeam.WestMidlands;
         var userDto = new UserDto
@@ -108,9 +114,15 @@ public class CreateTransferProjectCommandHandlerTests
         [Frozen] Mock<ISender> mockSender,
         CreateTransferProjectCommand command)
     {
-        var handler =
-            new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
-                mockSender.Object);
+        // Arrange
+        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+        var handler = new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
+            mockEstablishmentClient.Object,
+            mockSender.Object);
 
         command = command with
         {
@@ -169,9 +181,14 @@ public class CreateTransferProjectCommandHandlerTests
     )
     {
         // Arrange
-        var handler =
-            new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
-                mockSender.Object);
+        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+        var handler = new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
+            mockEstablishmentClient.Object,
+            mockSender.Object);
 
         command = command with { HandingOverToRegionalCaseworkService = true };
 
@@ -232,9 +249,14 @@ public class CreateTransferProjectCommandHandlerTests
     )
     {
         // Arrange
-        var handler =
-            new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
-                mockSender.Object);
+        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+        var handler = new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
+            mockEstablishmentClient.Object,
+            mockSender.Object);
 
         command = command with { HandingOverToRegionalCaseworkService = false };
 
@@ -294,6 +316,7 @@ public class CreateTransferProjectCommandHandlerTests
         CreateTransferProjectCommand command)
     {
         // Arrange
+        command = command with { HandingOverToRegionalCaseworkService = false};
         // Local Authority lookup succeeds.
         mockSender
             .Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), It.IsAny<CancellationToken>()))
@@ -305,10 +328,19 @@ public class CreateTransferProjectCommandHandlerTests
         mockSender
             .Setup(s => s.Send(It.IsAny<GetUserByAdIdQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<UserDto?>.Failure("User retrieval error"));
+        
+        var groupId = new ProjectGroupId(Guid.NewGuid());
+        mockSender.Setup(s =>
+                s.Send(It.IsAny<GetProjectGroupByGroupReferenceNumberQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<ProjectGroupDto>.Success(new ProjectGroupDto { Id = groupId }));
 
-        var handler = new CreateTransferProjectCommandHandler(
-            mockProjectRepository,
-            mockTransferTaskRepository,
+        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+        var handler = new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
+            mockEstablishmentClient.Object,
             mockSender.Object);
 
         // Act & Assert
@@ -355,9 +387,14 @@ public class CreateTransferProjectCommandHandlerTests
             .Setup(s => s.Send(It.IsAny<GetProjectGroupByGroupReferenceNumberQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<ProjectGroupDto?>.Failure("Project group retrieval error"));
 
-        var handler = new CreateTransferProjectCommandHandler(
-            mockProjectRepository,
-            mockTransferTaskRepository,
+        // Arrange
+        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+        var handler = new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
+            mockEstablishmentClient.Object,
             mockSender.Object);
 
         // Act & Assert
@@ -389,9 +426,14 @@ public class CreateTransferProjectCommandHandlerTests
                 .Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Failure("Local authority not found"));
             
-            var handler = new CreateTransferProjectCommandHandler(
-                mockProjectRepository,
-                mockTransferTaskRepository,
+            // Arrange
+            var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+            Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+            mockEstablishmentClient.Setup(mock =>
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+            var handler = new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
+                mockEstablishmentClient.Object,
                 mockSender.Object);
 
             // Act & Assert
@@ -424,9 +466,14 @@ public class CreateTransferProjectCommandHandlerTests
                 .Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(responseDto));
             
-            var handler = new CreateTransferProjectCommandHandler(
-                mockProjectRepository,
-                mockTransferTaskRepository,
+            // Arrange
+            var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+            Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+            mockEstablishmentClient.Setup(mock =>
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+            var handler = new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
+                mockEstablishmentClient.Object,
                 mockSender.Object);
 
             // Act & Assert
@@ -456,9 +503,14 @@ public class CreateTransferProjectCommandHandlerTests
                 .Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(null));
             
-            var handler = new CreateTransferProjectCommandHandler(
-                mockProjectRepository,
-                mockTransferTaskRepository,
+            // Arrange
+            var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+            Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+            mockEstablishmentClient.Setup(mock =>
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
+        
+            var handler = new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
+                mockEstablishmentClient.Object,
                 mockSender.Object);
 
             // Act & Assert

--- a/src/Tests/Dfe.Complete.Application.Tests/CommandHandlers/Project/CreateTransferProjectCommandHandlerTests.cs
+++ b/src/Tests/Dfe.Complete.Application.Tests/CommandHandlers/Project/CreateTransferProjectCommandHandlerTests.cs
@@ -34,11 +34,13 @@ public class CreateTransferProjectCommandHandlerTests
         CreateTransferProjectCommand command)
     {
         // Arrange
-        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
         Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
         mockEstablishmentClient.Setup(mock =>
-            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
         var handler = new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
             mockEstablishmentClient.Object,
             mockSender.Object);
@@ -115,11 +117,13 @@ public class CreateTransferProjectCommandHandlerTests
         CreateTransferProjectCommand command)
     {
         // Arrange
-        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
         Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
         mockEstablishmentClient.Setup(mock =>
-            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
         var handler = new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
             mockEstablishmentClient.Object,
             mockSender.Object);
@@ -181,11 +185,13 @@ public class CreateTransferProjectCommandHandlerTests
     )
     {
         // Arrange
-        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
         Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
         mockEstablishmentClient.Setup(mock =>
-            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
         var handler = new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
             mockEstablishmentClient.Object,
             mockSender.Object);
@@ -249,11 +255,13 @@ public class CreateTransferProjectCommandHandlerTests
     )
     {
         // Arrange
-        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
         Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
         mockEstablishmentClient.Setup(mock =>
-            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
         var handler = new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
             mockEstablishmentClient.Object,
             mockSender.Object);
@@ -306,7 +314,7 @@ public class CreateTransferProjectCommandHandlerTests
         Assert.NotNull(capturedProject.AssignedAt);
         Assert.NotNull(capturedProject.AssignedToId);
     }
-    
+
     [Theory]
     [CustomAutoData(typeof(DateOnlyCustomization))]
     public async Task Handle_ShouldThrowException_WhenUserRequestFails(
@@ -316,7 +324,7 @@ public class CreateTransferProjectCommandHandlerTests
         CreateTransferProjectCommand command)
     {
         // Arrange
-        command = command with { HandingOverToRegionalCaseworkService = false};
+        command = command with { HandingOverToRegionalCaseworkService = false };
         // Local Authority lookup succeeds.
         mockSender
             .Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), It.IsAny<CancellationToken>()))
@@ -328,17 +336,19 @@ public class CreateTransferProjectCommandHandlerTests
         mockSender
             .Setup(s => s.Send(It.IsAny<GetUserByAdIdQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<UserDto?>.Failure("User retrieval error"));
-        
+
         var groupId = new ProjectGroupId(Guid.NewGuid());
         mockSender.Setup(s =>
                 s.Send(It.IsAny<GetProjectGroupByGroupReferenceNumberQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<ProjectGroupDto>.Success(new ProjectGroupDto { Id = groupId }));
 
-        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
         Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
         mockEstablishmentClient.Setup(mock =>
-            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
         var handler = new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
             mockEstablishmentClient.Object,
             mockSender.Object);
@@ -388,11 +398,13 @@ public class CreateTransferProjectCommandHandlerTests
             .ReturnsAsync(Result<ProjectGroupDto?>.Failure("Project group retrieval error"));
 
         // Arrange
-        var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
         Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
         mockEstablishmentClient.Setup(mock =>
-            mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
         var handler = new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
             mockEstablishmentClient.Object,
             mockSender.Object);
@@ -409,121 +421,129 @@ public class CreateTransferProjectCommandHandlerTests
         await mockTransferTaskRepository.DidNotReceive()
             .AddAsync(Arg.Any<TransferTasksData>(), Arg.Any<CancellationToken>());
     }
-    
-          [Theory]
-        [CustomAutoData(typeof(DateOnlyCustomization))]
-        public async Task Handle_ShouldThrowException_WhenLocalAuthorityRequestFails(
-            [Frozen] ICompleteRepository<Domain.Entities.Project> mockProjectRepository,
-            [Frozen] ICompleteRepository<TransferTasksData> mockTransferTaskRepository,
-            [Frozen] Mock<ISender> mockSender,
-            CreateTransferProjectCommand command)
-        {
-            // Arrange
-            var expectedMessage =
-                $"No Local authority could be found via Establishments for School Urn: {command.Urn.Value}.";
-            
-            mockSender
-                .Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Failure("Local authority not found"));
-            
-            // Arrange
-            var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
-            Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
-            mockEstablishmentClient.Setup(mock =>
-                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
-            var handler = new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
-                mockEstablishmentClient.Object,
-                mockSender.Object);
 
-            // Act & Assert
-            var exception = await Assert.ThrowsAsync<NotFoundException>(() => handler.Handle(command, CancellationToken.None));
-            
-            Assert.Equal(expectedMessage, exception.Message);
-            Assert.NotNull(exception.InnerException);
-            Assert.Equal("Local authority not found", exception.InnerException.Message);
+    [Theory]
+    [CustomAutoData(typeof(DateOnlyCustomization))]
+    public async Task Handle_ShouldThrowException_WhenLocalAuthorityRequestFails(
+        [Frozen] ICompleteRepository<Domain.Entities.Project> mockProjectRepository,
+        [Frozen] ICompleteRepository<TransferTasksData> mockTransferTaskRepository,
+        [Frozen] Mock<ISender> mockSender,
+        CreateTransferProjectCommand command)
+    {
+        // Arrange
+        var expectedMessage =
+            $"No Local authority could be found via Establishments for School Urn: {command.Urn.Value}.";
 
-            await mockProjectRepository.DidNotReceive()
-                .AddAsync(Arg.Any<Domain.Entities.Project>(), Arg.Any<CancellationToken>());
-            await mockTransferTaskRepository.DidNotReceive()
-                .AddAsync(Arg.Any<TransferTasksData>(), Arg.Any<CancellationToken>());
-        }
+        mockSender
+            .Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Failure("Local authority not found"));
 
-        [Theory]
-        [CustomAutoData(typeof(DateOnlyCustomization))]
-        public async Task Handle_ShouldThrowException_WhenLocalAuthorityIdIsNull(
-            [Frozen] ICompleteRepository<Domain.Entities.Project> mockProjectRepository,
-            [Frozen] ICompleteRepository<TransferTasksData> mockTransferTaskRepository,
-            [Frozen] Mock<ISender> mockSender,
-            CreateTransferProjectCommand command)
-        {
-            // Arrange
-            var expectedMessage =
-                $"No Local authority could be found via Establishments for School Urn: {command.Urn.Value}.";
+        // Arrange
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
 
-            var responseDto = new GetLocalAuthorityBySchoolUrnResponseDto(null);
-            mockSender
-                .Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(responseDto));
-            
-            // Arrange
-            var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
-            Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
-            mockEstablishmentClient.Setup(mock =>
-                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
-            var handler = new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
-                mockEstablishmentClient.Object,
-                mockSender.Object);
+        var handler = new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
+            mockEstablishmentClient.Object,
+            mockSender.Object);
 
-            // Act & Assert
-            var exception = await Assert.ThrowsAsync<NotFoundException>(
-                () => handler.Handle(command, CancellationToken.None));
-            Assert.Equal(expectedMessage, exception.Message);
+        // Act & Assert
+        var exception =
+            await Assert.ThrowsAsync<NotFoundException>(() => handler.Handle(command, CancellationToken.None));
 
-            await mockProjectRepository.DidNotReceive()
-                .AddAsync(Arg.Any<Domain.Entities.Project>(), Arg.Any<CancellationToken>());
-            await mockTransferTaskRepository.DidNotReceive()
-                .AddAsync(Arg.Any<TransferTasksData>(), Arg.Any<CancellationToken>());
-        }
-        
-        [Theory]
-        [CustomAutoData(typeof(DateOnlyCustomization))]
-        public async Task Handle_ShouldThrowException_WhenLocalAuthorityRequestSuccess_WithNullResponse(
-            [Frozen] ICompleteRepository<Domain.Entities.Project> mockProjectRepository,
-            [Frozen] ICompleteRepository<TransferTasksData> mockTransferTaskRepository,
-            [Frozen] Mock<ISender> mockSender,
-            CreateTransferProjectCommand command)
-        {
-            // Arrange
-            var expectedMessage =
-                $"No Local authority could be found via Establishments for School Urn: {command.Urn.Value}.";
+        Assert.Equal(expectedMessage, exception.Message);
+        Assert.NotNull(exception.InnerException);
+        Assert.Equal("Local authority not found", exception.InnerException.Message);
 
-            mockSender
-                .Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(null));
-            
-            // Arrange
-            var establishmentDto = new EstablishmentDto { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto{ Code = "H" } };
-            Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
-            mockEstablishmentClient.Setup(mock =>
-                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>())).ReturnsAsync(establishmentDto);
-        
-            var handler = new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
-                mockEstablishmentClient.Object,
-                mockSender.Object);
+        await mockProjectRepository.DidNotReceive()
+            .AddAsync(Arg.Any<Domain.Entities.Project>(), Arg.Any<CancellationToken>());
+        await mockTransferTaskRepository.DidNotReceive()
+            .AddAsync(Arg.Any<TransferTasksData>(), Arg.Any<CancellationToken>());
+    }
 
-            // Act & Assert
-            var exception = await Assert.ThrowsAsync<NotFoundException>(() => handler.Handle(command, CancellationToken.None));
-            Assert.Equal(expectedMessage, exception.Message);
+    [Theory]
+    [CustomAutoData(typeof(DateOnlyCustomization))]
+    public async Task Handle_ShouldThrowException_WhenLocalAuthorityIdIsNull(
+        [Frozen] ICompleteRepository<Domain.Entities.Project> mockProjectRepository,
+        [Frozen] ICompleteRepository<TransferTasksData> mockTransferTaskRepository,
+        [Frozen] Mock<ISender> mockSender,
+        CreateTransferProjectCommand command)
+    {
+        // Arrange
+        var expectedMessage =
+            $"No Local authority could be found via Establishments for School Urn: {command.Urn.Value}.";
 
-            await mockProjectRepository.DidNotReceive()
-                .AddAsync(Arg.Any<Domain.Entities.Project>(), Arg.Any<CancellationToken>());
-            await mockTransferTaskRepository.DidNotReceive()
-                .AddAsync(Arg.Any<TransferTasksData>(), Arg.Any<CancellationToken>());
-        }
-        
-         [Theory]
+        var responseDto = new GetLocalAuthorityBySchoolUrnResponseDto(null);
+        mockSender
+            .Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(responseDto));
+
+        // Arrange
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
+        var handler = new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
+            mockEstablishmentClient.Object,
+            mockSender.Object);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<NotFoundException>(
+            () => handler.Handle(command, CancellationToken.None));
+        Assert.Equal(expectedMessage, exception.Message);
+
+        await mockProjectRepository.DidNotReceive()
+            .AddAsync(Arg.Any<Domain.Entities.Project>(), Arg.Any<CancellationToken>());
+        await mockTransferTaskRepository.DidNotReceive()
+            .AddAsync(Arg.Any<TransferTasksData>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [CustomAutoData(typeof(DateOnlyCustomization))]
+    public async Task Handle_ShouldThrowException_WhenLocalAuthorityRequestSuccess_WithNullResponse(
+        [Frozen] ICompleteRepository<Domain.Entities.Project> mockProjectRepository,
+        [Frozen] ICompleteRepository<TransferTasksData> mockTransferTaskRepository,
+        [Frozen] Mock<ISender> mockSender,
+        CreateTransferProjectCommand command)
+    {
+        // Arrange
+        var expectedMessage =
+            $"No Local authority could be found via Establishments for School Urn: {command.Urn.Value}.";
+
+        mockSender
+            .Setup(s => s.Send(It.IsAny<GetLocalAuthorityBySchoolUrnQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<GetLocalAuthorityBySchoolUrnResponseDto?>.Success(null));
+
+        // Arrange
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
+        var handler = new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
+            mockEstablishmentClient.Object,
+            mockSender.Object);
+
+        // Act & Assert
+        var exception =
+            await Assert.ThrowsAsync<NotFoundException>(() => handler.Handle(command, CancellationToken.None));
+        Assert.Equal(expectedMessage, exception.Message);
+
+        await mockProjectRepository.DidNotReceive()
+            .AddAsync(Arg.Any<Domain.Entities.Project>(), Arg.Any<CancellationToken>());
+        await mockTransferTaskRepository.DidNotReceive()
+            .AddAsync(Arg.Any<TransferTasksData>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
     [CustomAutoData(typeof(DateOnlyCustomization), typeof(ProjectCustomization),
         typeof(IgnoreVirtualMembersCustomisation))]
     public async Task Handle_ShouldNOTSet_GroupId_When_GroupReferenceNumber_NullOrEmpty(
@@ -534,8 +554,16 @@ public class CreateTransferProjectCommandHandlerTests
     )
     {
         // Arrange
+        var establishmentDto = new EstablishmentDto
+            { Urn = command.Urn.Value.ToString(), Gor = new NameAndCodeDto { Code = "H" } };
+        Mock<IEstablishmentsV4Client> mockEstablishmentClient = new Mock<IEstablishmentsV4Client>();
+        mockEstablishmentClient.Setup(mock =>
+                mock.GetEstablishmentByUrnAsync(command.Urn.Value.ToString(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(establishmentDto);
+
         var handler =
             new CreateTransferProjectCommandHandler(mockProjectRepository, mockTransferTaskRepository,
+                mockEstablishmentClient.Object,
                 mockSender.Object);
 
         command = command with { GroupReferenceNumber = null };
@@ -559,7 +587,7 @@ public class CreateTransferProjectCommandHandlerTests
 
         mockSender.Setup(s => s.Send(It.IsAny<GetUserByAdIdQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result<UserDto?>.Success(userDto));
-        
+
         Domain.Entities.Project capturedProject = null!;
 
         mockProjectRepository.AddAsync(Arg.Do<Domain.Entities.Project>(proj => capturedProject = proj),
@@ -579,5 +607,4 @@ public class CreateTransferProjectCommandHandlerTests
         Assert.NotNull(projectId);
         Assert.Null(capturedProject.GroupId);
     }
-   
 }

--- a/src/Tests/Dfe.Complete.Tests.Common/Customizations/Models/AcademiesApiEstablishmentDtoCustomisation.cs
+++ b/src/Tests/Dfe.Complete.Tests.Common/Customizations/Models/AcademiesApiEstablishmentDtoCustomisation.cs
@@ -1,0 +1,18 @@
+﻿using AutoFixture;
+using Dfe.AcademiesApi.Client.Contracts;
+using DfE.CoreLibs.Testing.AutoFixture.Customizations;
+
+namespace Dfe.Complete.Tests.Common.Customizations.Models;
+
+public class AcademiesApiEstablishmentDtoCustomisation : ICustomization
+{
+    public string? Urn { get; set; }
+
+    public void Customize(IFixture fixture)
+    {
+        fixture
+            .Customize(new CompositeCustomization(
+                new DateOnlyCustomization()))
+            .Customize<EstablishmentDto>(composer => composer.With(x => x.Urn, new Random().Next(100000, 199999).ToString()));
+    }
+}

--- a/src/Tests/Dfe.Complete.Tests.Common/Customizations/Models/AcademiesApiEstablishmentDtoCustomisation.cs
+++ b/src/Tests/Dfe.Complete.Tests.Common/Customizations/Models/AcademiesApiEstablishmentDtoCustomisation.cs
@@ -8,11 +8,15 @@ public class AcademiesApiEstablishmentDtoCustomisation : ICustomization
 {
     public string? Urn { get; set; }
 
+    public NameAndCodeDto? Gor { get; set; }
     public void Customize(IFixture fixture)
     {
         fixture
             .Customize(new CompositeCustomization(
-                new DateOnlyCustomization()))
-            .Customize<EstablishmentDto>(composer => composer.With(x => x.Urn, new Random().Next(100000, 199999).ToString()));
+                new DateOnlyCustomization(), new NameAndCodeDtoCustomisation()))
+            .Customize<EstablishmentDto>(composer => 
+                composer.With(x => x.Urn, new Random().Next(100000, 199999).ToString())
+                    .With(x => x.Gor, Gor ?? fixture.Customize(new NameAndCodeDtoCustomisation()).Create<NameAndCodeDto>())
+                );
     }
 }

--- a/src/Tests/Dfe.Complete.Tests.Common/Customizations/Models/EstablishmentsCustomization.cs
+++ b/src/Tests/Dfe.Complete.Tests.Common/Customizations/Models/EstablishmentsCustomization.cs
@@ -8,6 +8,7 @@ namespace Dfe.Complete.Tests.Common.Customizations.Models
     public class EstablishmentsCustomization : ICustomization
     {
         public Urn? Urn { get; set; }
+        public string? LocalAuthorityCode { get; set; }
 
         public void Customize(IFixture fixture)
         {
@@ -16,7 +17,10 @@ namespace Dfe.Complete.Tests.Common.Customizations.Models
             fixture
                 .Customize(new CompositeCustomization(
                    new DateOnlyCustomization()))
-                .Customize<GiasEstablishment>(composer => composer);
+                .Customize<GiasEstablishment>(composer => composer
+                    .With(x => x.Urn, Urn ?? fixture.Create<Urn>())
+                    .With(x => x.LocalAuthorityCode, LocalAuthorityCode ?? fixture.Create<LocalAuthority>().ToString())
+                );
         }
     }
 }

--- a/src/Tests/Dfe.Complete.Tests.Common/Customizations/Models/EstablishmentsCustomization.cs
+++ b/src/Tests/Dfe.Complete.Tests.Common/Customizations/Models/EstablishmentsCustomization.cs
@@ -1,6 +1,8 @@
 ﻿using AutoFixture;
 using Dfe.Complete.Domain.Entities;
+using Dfe.Complete.Domain.Enums;
 using Dfe.Complete.Domain.ValueObjects;
+using Dfe.Complete.Utils;
 using DfE.CoreLibs.Testing.AutoFixture.Customizations;
 
 namespace Dfe.Complete.Tests.Common.Customizations.Models
@@ -9,10 +11,14 @@ namespace Dfe.Complete.Tests.Common.Customizations.Models
     {
         public Urn? Urn { get; set; }
         public string? LocalAuthorityCode { get; set; }
+        
+        public Region? Region { get; set; }
 
         public void Customize(IFixture fixture)
         {
             fixture.Customizations.Add(new UrnSpecimen());
+
+            var region = fixture.Create<Region>();
 
             fixture
                 .Customize(new CompositeCustomization(
@@ -20,6 +26,8 @@ namespace Dfe.Complete.Tests.Common.Customizations.Models
                 .Customize<GiasEstablishment>(composer => composer
                     .With(x => x.Urn, Urn ?? fixture.Create<Urn>())
                     .With(x => x.LocalAuthorityCode, LocalAuthorityCode ?? fixture.Create<LocalAuthority>().ToString())
+                    .With(x => x.RegionCode, !string.IsNullOrEmpty(Region.GetCharValue()) ? Region.GetCharValue() : region.GetCharValue())
+                    .With(x => x.RegionName, !string.IsNullOrEmpty(Region.ToDescription()) ? Region.ToDescription() : region.ToDescription())
                 );
         }
     }

--- a/src/Tests/Dfe.Complete.Tests.Common/Customizations/Models/NameAndCodeDtoCustomisation.cs
+++ b/src/Tests/Dfe.Complete.Tests.Common/Customizations/Models/NameAndCodeDtoCustomisation.cs
@@ -1,0 +1,22 @@
+﻿using AutoFixture;
+using Dfe.AcademiesApi.Client.Contracts;
+using Dfe.Complete.Domain.Enums;
+using Dfe.Complete.Utils;
+using DfE.CoreLibs.Testing.AutoFixture.Customizations;
+
+namespace Dfe.Complete.Tests.Common.Customizations.Models;
+
+public class NameAndCodeDtoCustomisation : ICustomization
+{
+    public void Customize(IFixture fixture)
+    {
+        var region = fixture.Create<Region>();
+        fixture
+            .Customize(new CompositeCustomization(
+                new DateOnlyCustomization()))
+            .Customize<NameAndCodeDto>(composer => 
+                composer.With(x => x.Code, region.GetCharValue())
+                    .With(x => x.Name, region.ToDescription())
+            );
+    }
+}


### PR DESCRIPTION
Fix the error handling for users in the create project handlers, allowing for user id to be optional
Fix the region assigned to projects to match how the ruby app fetches projects
Add wiremock to the testing framework for mocking calls to the Academies API