### PR TITLE
Add DbContextChecks to Health Checks

### DIFF
--- a/src/Api/Dfe.Complete.Api/Program.cs
+++ b/src/Api/Dfe.Complete.Api/Program.cs
@@ -26,7 +26,7 @@ namespace Dfe.Complete.Api
         public static async Task Main(string[] args)
         {
             var builder = WebApplication.CreateBuilder(args);
-            
+
             builder.Host.UseSerilog((context, services, loggerConfiguration) =>
             {
                 loggerConfiguration
@@ -45,7 +45,7 @@ namespace Dfe.Complete.Api
                 config.DefaultApiVersion = new ApiVersion(1, 0);
                 config.AssumeDefaultVersionWhenUnspecified = true;
                 config.ReportApiVersions = true;
-                
+
             }).AddApiExplorer(options =>
             {
                 options.GroupNameFormat = "'v'VVV";
@@ -180,6 +180,8 @@ namespace Dfe.Complete.Api
             app.UseAuthentication();
             app.UseAuthorization();
             app.MapControllers();
+
+            app.MapHealthChecks("/health").AllowAnonymous();
 
             ILogger<Program> logger = app.Services.GetRequiredService<ILogger<Program>>();
             logger.LogInformation("Logger is working...");

--- a/src/Core/Dfe.Complete.Infrastructure/Dfe.Complete.Infrastructure.csproj
+++ b/src/Core/Dfe.Complete.Infrastructure/Dfe.Complete.Infrastructure.csproj
@@ -14,6 +14,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.14" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.14" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.14" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="3.5.0" />
   </ItemGroup>

--- a/src/Core/Dfe.Complete.Infrastructure/InfrastructureServiceCollectionExtensions.cs
+++ b/src/Core/Dfe.Complete.Infrastructure/InfrastructureServiceCollectionExtensions.cs
@@ -37,7 +37,14 @@ namespace Dfe.Complete.Infrastructure
             // Authentication
             //services.AddCustomAuthorization(config);
 
+            AddInfrastructureHealthChecks(services);
+
             return services;
+        }
+
+        public static void AddInfrastructureHealthChecks(this IServiceCollection services) {
+            services.AddHealthChecks()
+                .AddDbContextCheck<CompleteContext>("Complete Database");
         }
     }
 }


### PR DESCRIPTION
This will ensure that the /health endpoint correctly reports the status of the service if a database connection faults