### PR TITLE
Bugfix/187132 your team projects error

### DIFF
--- a/src/Frontend/Dfe.Complete/Pages/Projects/List/ProjectsForTeam/AllProjectsInProgressForTeam.cshtml
+++ b/src/Frontend/Dfe.Complete/Pages/Projects/List/ProjectsForTeam/AllProjectsInProgressForTeam.cshtml
@@ -15,52 +15,59 @@
     </h1>
 }
 
-<div class="govuk-grid-column-full">
-    <table class="govuk-table" name="projects_table" aria-label="Projects table">
-        <thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-                <th class="govuk-table__header" scope="col">School or academy</th>
-                <th class="govuk-table__header" scope="col">URN</th>
-                <th class="govuk-table__header" scope="col">Local authority</th>
-                @if (Model.UserTeamIsRdo)
-                {
-                    <th class="govuk-table__header" scope="col">Team</th>
-                }
-                else
-                {
-                    <th class="govuk-table__header" scope="col">Region</th>
-                }
-                <th class="govuk-table__header" scope="col">Assigned to</th>
-                <th class="govuk-table__header" scope="col">Project type</th>
-                <th class="govuk-table__header" scope="col">Form a MAT project?</th>
-                <th class="govuk-table__header" scope="col">Conversion or transfer date</th>
-            </tr>
-        </thead>
-        <tbody class="govuk-table__body">
-
-            @foreach (var project in Model.Projects)
-            {
+@if (Model.Projects == null || Model.Projects.Count == 0)
+{
+    <div class="govuk-inset-text">There are no projects in progress.</div>
+}
+else
+{
+    <div class="govuk-grid-column-full">
+        <table class="govuk-table" name="projects_table" aria-label="Projects table">
+            <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
-                    <td class="govuk-table__header govuk-table__cell">
-                        <a class="govuk-link"
-                            href="@AllProjectsModel.GetProjectSummaryUrl(project)">@project.EstablishmentName</a>
-                    </td>
-                    <td class="govuk-table__cell">@project.Urn.Value</td>
-                    <td class="govuk-table__cell">@project.LocalAuthorityNameFormatted</td>
+                    <th class="govuk-table__header" scope="col">School or academy</th>
+                    <th class="govuk-table__header" scope="col">URN</th>
+                    <th class="govuk-table__header" scope="col">Local authority</th>
                     @if (Model.UserTeamIsRdo)
                     {
-                        <td class="govuk-table__cell">@ProjectTeamPresentationMapper.Map(@project.Team)</td>
+                        <th class="govuk-table__header" scope="col">Team</th>
                     }
                     else
                     {
-                        <td class="govuk-table__cell">@project.Region.ToDisplayDescription()</td>
+                        <th class="govuk-table__header" scope="col">Region</th>
                     }
-                    <td class="govuk-table__cell">@project.AssignedToFullName</td>
-                    <td class="govuk-table__cell">@project.ProjectType.ToString()</td>
-                    <td class="govuk-table__cell">@project.IsFormAMAT.ToYesNoString()</td>
-                    <td class="govuk-table__cell">@project.ConversionOrTransferDate.ToDateMonthYearString()</td>
+                    <th class="govuk-table__header" scope="col">Assigned to</th>
+                    <th class="govuk-table__header" scope="col">Project type</th>
+                    <th class="govuk-table__header" scope="col">Form a MAT project?</th>
+                    <th class="govuk-table__header" scope="col">Conversion or transfer date</th>
                 </tr>
-            }
-        </tbody>
-    </table>
-</div>
+            </thead>
+            <tbody class="govuk-table__body">
+
+                @foreach (var project in Model.Projects)
+                {
+                    <tr class="govuk-table__row">
+                        <td class="govuk-table__header govuk-table__cell">
+                            <a class="govuk-link"
+                                href="@AllProjectsModel.GetProjectSummaryUrl(project)">@project.EstablishmentName</a>
+                        </td>
+                        <td class="govuk-table__cell">@project.Urn.Value</td>
+                        <td class="govuk-table__cell">@project.LocalAuthorityNameFormatted</td>
+                        @if (Model.UserTeamIsRdo)
+                        {
+                            <td class="govuk-table__cell">@ProjectTeamPresentationMapper.Map(@project.Team)</td>
+                        }
+                        else
+                        {
+                            <td class="govuk-table__cell">@project.Region.ToDisplayDescription()</td>
+                        }
+                        <td class="govuk-table__cell">@project.AssignedToFullName</td>
+                        <td class="govuk-table__cell">@project.ProjectType.ToString()</td>
+                        <td class="govuk-table__cell">@project.IsFormAMAT.ToYesNoString()</td>
+                        <td class="govuk-table__cell">@project.ConversionOrTransferDate.ToDateMonthYearString()</td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}

--- a/src/Frontend/Dfe.Complete/Pages/Projects/List/ProjectsForTeam/AllProjectsInProgressForTeamModel.cshtml.cs
+++ b/src/Frontend/Dfe.Complete/Pages/Projects/List/ProjectsForTeam/AllProjectsInProgressForTeamModel.cshtml.cs
@@ -12,7 +12,7 @@ namespace Dfe.Complete.Pages.Projects.List.ProjectsForTeam;
 
 public class AllProjectsInProgressForTeamModel(ISender sender) : YourTeamProjectsModel(InProgressNavigation)
 {
-    public List<ListAllProjectsResultModel> Projects { get; set; } = default!;
+    public List<ListAllProjectsResultModel> Projects { get; set; } = [];
     public bool UserTeamIsRdo { get; set; }
 
     public async Task OnGet()


### PR DESCRIPTION
When accessing the team projects in progress tab by url, users that do not have access to the tab see an unhandled exception instead.

Ruby displays the no projects message instead. I'm not sure that this is the desired behaviour but this PR does align the behaviours (and is more desirable that unhandled exception at least).
