### PR TITLE
Bugfix/209630 check for null assignee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Security in case of vulnerabilities.
 
 ### Fixed
  - Correctly identify test env based on environment name being "Test" (previously looking for "Staging")
+ - null `AssignedTo` in `ListAllProjects` throws an unexpected error
 
 See the [full commit history](https://github.com/DFE-Digital/complete-conversions-transfers-changes/compare/main...production-2025-04-01.120-manual) for everything awaiting release
 

--- a/src/Core/Dfe.Complete.Application/Projects/Queries/ListAllProjects/ListAllProjects.cs
+++ b/src/Core/Dfe.Complete.Application/Projects/Queries/ListAllProjects/ListAllProjects.cs
@@ -27,25 +27,26 @@ namespace Dfe.Complete.Application.Projects.Queries.ListAllProjects
                     .ToListAsync(cancellationToken);
                 
                 var filteredProjectList = request.ProjectStatus == ProjectState.Active
-                    ? projectList.Where(p => p.Project.AssignedTo != null)
+                    ? projectList.Where(p => p.Project?.AssignedTo != null)
                     : projectList;
                 
                 var result = filteredProjectList
                     .Skip(request.Page * request.Count).Take(request.Count)
                     .Select(item => new ListAllProjectsResultModel(
-                        item.Establishment.Name,
-                        item.Project.Id,
+                        item.Establishment?.Name,
+                        item.Project!.Id,
                         item.Project.Urn,
                         item.Project.SignificantDate,
                         item.Project.State,
                         item.Project.Type,
                         item.Project.FormAMat,
-                        $"{item.Project.AssignedTo.FirstName} {item.Project.AssignedTo.LastName}",
-                        item.Project.LocalAuthority.Name,
+                        item.Project.AssignedTo != null
+                            ? $"{item.Project.AssignedTo.FirstName} {item.Project.AssignedTo.LastName}"
+                            : null, item.Project.LocalAuthority.Name,
                         item.Project.Team,
                         item.Project.CompletedAt,
                         item.Project.Region,
-                        item.Establishment.LocalAuthorityName
+                        item.Establishment?.LocalAuthorityName
                     ))
                     .ToList();
                 return Result<List<ListAllProjectsResultModel>>.Success(result);

--- a/src/Core/Dfe.Complete.Application/Projects/Queries/ListAllProjects/ListAllProjects.cs
+++ b/src/Core/Dfe.Complete.Application/Projects/Queries/ListAllProjects/ListAllProjects.cs
@@ -40,9 +40,8 @@ namespace Dfe.Complete.Application.Projects.Queries.ListAllProjects
                         item.Project.State,
                         item.Project.Type,
                         item.Project.FormAMat,
-                        item.Project.AssignedTo != null
-                            ? $"{item.Project.AssignedTo.FirstName} {item.Project.AssignedTo.LastName}"
-                            : null, item.Project.LocalAuthority.Name,
+                        item.Project.AssignedTo?.FullName,
+                        item.Project.LocalAuthority.Name,
                         item.Project.Team,
                         item.Project.CompletedAt,
                         item.Project.Region,


### PR DESCRIPTION
I've added a bit of a regression-unit-test. It looks for some of the fields that could be null and just checks that we're not throwing if null checks are removed by mistake. Not strictly necessary and I can remove it