### PR TITLE
Handled GET /sign-in (false) issue correctly by lowercasing the cookie value

### DIFF
--- a/src/Frontend/Dfe.Complete/Services/AnalyticsConsentService.cs
+++ b/src/Frontend/Dfe.Complete/Services/AnalyticsConsentService.cs
@@ -59,7 +59,7 @@
         {
             Consent = consent;
             var cookieOptions = new CookieOptions { Expires = DateTime.Today.AddMonths(6), Secure = true, HttpOnly = true };
-            _httpContextAccessor.HttpContext.Response.Cookies.Append(ConsentCookieName, consent.ToString(), cookieOptions);
+            _httpContextAccessor.HttpContext!.Response.Cookies.Append(ConsentCookieName, consent.ToString().ToLower(), cookieOptions);
             var request = _httpContextAccessor.HttpContext.Request;
 
 			if (!consent)

--- a/src/Tests/Dfe.Complete.CypressTests/cypress/pages/cookies.ts
+++ b/src/Tests/Dfe.Complete.CypressTests/cypress/pages/cookies.ts
@@ -6,12 +6,12 @@ class Cookies {
     private readonly cookieBannerId = "appCookieBanner";
 
     public consentCookieIsSetToTrue() {
-        cy.getCookie(this.consentCookie).should("exist").should("have.property", "value", "True");
+        cy.getCookie(this.consentCookie).should("exist").should("have.property", "value", "true");
         return this;
     }
 
     public consentCookieIsSetToFalse() {
-        cy.getCookie(this.consentCookie).should("exist").should("have.property", "value", "False");
+        cy.getCookie(this.consentCookie).should("exist").should("have.property", "value", "false");
         return this;
     }
 


### PR DESCRIPTION
Handled GET /sign-in (false) issue correctly by lowercasing the accept cookie value
Screenshot
![image](https://github.com/user-attachments/assets/39bc8c91-2ccb-4568-8ca4-b5b34be78dd7)

[Azure DevOps ticket](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/210932)