### PR TITLE
Change/210197 move pagination to repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Security in case of vulnerabilities.
 ### Added  
 
 ### Changed  
+ - Optimise several project listing queries by implementing pagination before retrieving records
 
 ### Fixed  
 

--- a/src/Api/Dfe.Complete.Api.Client/Generated/Client.g.cs
+++ b/src/Api/Dfe.Complete.Api.Client/Generated/Client.g.cs
@@ -1000,9 +1000,9 @@ namespace Dfe.Complete.Client
         /// </summary>
         /// <returns>Project</returns>
         /// <exception cref="CompleteApiException">A server side error occurred.</exception>
-        public virtual System.Threading.Tasks.Task<System.Collections.ObjectModel.ObservableCollection<ListAllProjectsResultModel>> ListAllProjectsAsync(ProjectState? projectStatus, ProjectType? type, int? page, int? count)
+        public virtual System.Threading.Tasks.Task<System.Collections.ObjectModel.ObservableCollection<ListAllProjectsResultModel>> ListAllProjectsAsync(ProjectState? projectStatus, ProjectType? type, AssignedToState? assignedToState, int? page, int? count)
         {
-            return ListAllProjectsAsync(projectStatus, type, page, count, System.Threading.CancellationToken.None);
+            return ListAllProjectsAsync(projectStatus, type, assignedToState, page, count, System.Threading.CancellationToken.None);
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -1011,7 +1011,7 @@ namespace Dfe.Complete.Client
         /// </summary>
         /// <returns>Project</returns>
         /// <exception cref="CompleteApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<System.Collections.ObjectModel.ObservableCollection<ListAllProjectsResultModel>> ListAllProjectsAsync(ProjectState? projectStatus, ProjectType? type, int? page, int? count, System.Threading.CancellationToken cancellationToken)
+        public virtual async System.Threading.Tasks.Task<System.Collections.ObjectModel.ObservableCollection<ListAllProjectsResultModel>> ListAllProjectsAsync(ProjectState? projectStatus, ProjectType? type, AssignedToState? assignedToState, int? page, int? count, System.Threading.CancellationToken cancellationToken)
         {
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -1034,6 +1034,10 @@ namespace Dfe.Complete.Client
                     if (type != null)
                     {
                         urlBuilder_.Append(System.Uri.EscapeDataString("Type")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(type, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    if (assignedToState != null)
+                    {
+                        urlBuilder_.Append(System.Uri.EscapeDataString("AssignedToState")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(assignedToState, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
                     }
                     if (page != null)
                     {

--- a/src/Api/Dfe.Complete.Api.Client/Generated/Client.g.cs
+++ b/src/Api/Dfe.Complete.Api.Client/Generated/Client.g.cs
@@ -1324,9 +1324,9 @@ namespace Dfe.Complete.Client
         /// </summary>
         /// <returns>Project</returns>
         /// <exception cref="CompleteApiException">A server side error occurred.</exception>
-        public virtual System.Threading.Tasks.Task<int> CountAllProjectsAsync(ProjectState? projectStatus, ProjectType? type, string? search)
+        public virtual System.Threading.Tasks.Task<int> CountAllProjectsAsync(ProjectState? projectStatus, ProjectType? type, AssignedToState? assignedToState, string? search)
         {
-            return CountAllProjectsAsync(projectStatus, type, search, System.Threading.CancellationToken.None);
+            return CountAllProjectsAsync(projectStatus, type, assignedToState, search, System.Threading.CancellationToken.None);
         }
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -1335,7 +1335,7 @@ namespace Dfe.Complete.Client
         /// </summary>
         /// <returns>Project</returns>
         /// <exception cref="CompleteApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<int> CountAllProjectsAsync(ProjectState? projectStatus, ProjectType? type, string? search, System.Threading.CancellationToken cancellationToken)
+        public virtual async System.Threading.Tasks.Task<int> CountAllProjectsAsync(ProjectState? projectStatus, ProjectType? type, AssignedToState? assignedToState, string? search, System.Threading.CancellationToken cancellationToken)
         {
             var client_ = _httpClient;
             var disposeClient_ = false;
@@ -1358,6 +1358,10 @@ namespace Dfe.Complete.Client
                     if (type != null)
                     {
                         urlBuilder_.Append(System.Uri.EscapeDataString("Type")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(type, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    if (assignedToState != null)
+                    {
+                        urlBuilder_.Append(System.Uri.EscapeDataString("AssignedToState")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(assignedToState, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
                     }
                     if (search != null)
                     {

--- a/src/Api/Dfe.Complete.Api.Client/Generated/Contracts.g.cs
+++ b/src/Api/Dfe.Complete.Api.Client/Generated/Contracts.g.cs
@@ -155,7 +155,7 @@ namespace Dfe.Complete.Client.Contracts
         /// </summary>
         /// <returns>Project</returns>
         /// <exception cref="CompleteApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<System.Collections.ObjectModel.ObservableCollection<ListAllProjectsResultModel>> ListAllProjectsAsync(ProjectState? projectStatus, ProjectType? type, int? page, int? count);
+        System.Threading.Tasks.Task<System.Collections.ObjectModel.ObservableCollection<ListAllProjectsResultModel>> ListAllProjectsAsync(ProjectState? projectStatus, ProjectType? type, AssignedToState? assignedToState, int? page, int? count);
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
@@ -163,7 +163,7 @@ namespace Dfe.Complete.Client.Contracts
         /// </summary>
         /// <returns>Project</returns>
         /// <exception cref="CompleteApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<System.Collections.ObjectModel.ObservableCollection<ListAllProjectsResultModel>> ListAllProjectsAsync(ProjectState? projectStatus, ProjectType? type, int? page, int? count, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.ObjectModel.ObservableCollection<ListAllProjectsResultModel>> ListAllProjectsAsync(ProjectState? projectStatus, ProjectType? type, AssignedToState? assignedToState, int? page, int? count, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
         /// Returns a list of Projects related to a specific trust
@@ -1703,6 +1703,18 @@ namespace Dfe.Complete.Client.Contracts
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.2.0.0 (NJsonSchema v11.1.0.0 (Newtonsoft.Json v13.0.0.0))")]
+    public enum AssignedToState
+    {
+
+        [System.Runtime.Serialization.EnumMember(Value = @"AssignedOnly")]
+        AssignedOnly = 0,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"UnassignedOnly")]
+        UnassignedOnly = 1,
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.2.0.0 (NJsonSchema v11.1.0.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class ListMatResultModel
     {
         [Newtonsoft.Json.JsonProperty("identifier", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -1880,18 +1892,6 @@ namespace Dfe.Complete.Client.Contracts
             return Newtonsoft.Json.JsonConvert.DeserializeObject<GiasEstablishmentId>(data, new Newtonsoft.Json.JsonSerializerSettings());
 
         }
-
-    }
-
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.2.0.0 (NJsonSchema v11.1.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public enum AssignedToState
-    {
-
-        [System.Runtime.Serialization.EnumMember(Value = @"AssignedOnly")]
-        AssignedOnly = 0,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"UnassignedOnly")]
-        UnassignedOnly = 1,
 
     }
 

--- a/src/Api/Dfe.Complete.Api.Client/Generated/Contracts.g.cs
+++ b/src/Api/Dfe.Complete.Api.Client/Generated/Contracts.g.cs
@@ -200,7 +200,7 @@ namespace Dfe.Complete.Client.Contracts
         /// </summary>
         /// <returns>Project</returns>
         /// <exception cref="CompleteApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<int> CountAllProjectsAsync(ProjectState? projectStatus, ProjectType? type, string? search);
+        System.Threading.Tasks.Task<int> CountAllProjectsAsync(ProjectState? projectStatus, ProjectType? type, AssignedToState? assignedToState, string? search);
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
@@ -208,7 +208,7 @@ namespace Dfe.Complete.Client.Contracts
         /// </summary>
         /// <returns>Project</returns>
         /// <exception cref="CompleteApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<int> CountAllProjectsAsync(ProjectState? projectStatus, ProjectType? type, string? search, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<int> CountAllProjectsAsync(ProjectState? projectStatus, ProjectType? type, AssignedToState? assignedToState, string? search, System.Threading.CancellationToken cancellationToken);
 
         /// <summary>
         /// Returns a list of Projects for a local authority

--- a/src/Api/Dfe.Complete.Api.Client/Generated/swagger.json
+++ b/src/Api/Dfe.Complete.Api.Client/Generated/swagger.json
@@ -333,13 +333,26 @@
             "x-position": 2
           },
           {
+            "name": "AssignedToState",
+            "in": "query",
+            "schema": {
+              "nullable": true,
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/AssignedToState"
+                }
+              ]
+            },
+            "x-position": 3
+          },
+          {
             "name": "Page",
             "in": "query",
             "schema": {
               "type": "integer",
               "format": "int32"
             },
-            "x-position": 3
+            "x-position": 4
           },
           {
             "name": "Count",
@@ -348,7 +361,7 @@
               "type": "integer",
               "format": "int32"
             },
-            "x-position": 4
+            "x-position": 5
           }
         ],
         "responses": {
@@ -2682,6 +2695,18 @@
           }
         }
       },
+      "AssignedToState": {
+        "type": "string",
+        "description": "",
+        "x-enumNames": [
+          "AssignedOnly",
+          "UnassignedOnly"
+        ],
+        "enum": [
+          "AssignedOnly",
+          "UnassignedOnly"
+        ]
+      },
       "ListMatResultModel": {
         "type": "object",
         "additionalProperties": false,
@@ -2874,18 +2899,6 @@
             "format": "guid"
           }
         }
-      },
-      "AssignedToState": {
-        "type": "string",
-        "description": "",
-        "x-enumNames": [
-          "AssignedOnly",
-          "UnassignedOnly"
-        ],
-        "enum": [
-          "AssignedOnly",
-          "UnassignedOnly"
-        ]
       },
       "OrderProjectByField": {
         "type": "string",

--- a/src/Api/Dfe.Complete.Api.Client/Generated/swagger.json
+++ b/src/Api/Dfe.Complete.Api.Client/Generated/swagger.json
@@ -538,13 +538,26 @@
             "x-position": 2
           },
           {
+            "name": "AssignedToState",
+            "in": "query",
+            "schema": {
+              "nullable": true,
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/AssignedToState"
+                }
+              ]
+            },
+            "x-position": 3
+          },
+          {
             "name": "Search",
             "in": "query",
             "schema": {
               "type": "string",
               "nullable": true
             },
-            "x-position": 3
+            "x-position": 4
           }
         ],
         "responses": {
@@ -2730,12 +2743,7 @@
         "additionalProperties": false,
         "properties": {
           "project": {
-            "nullable": true,
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/Project"
-              }
-            ]
+            "$ref": "#/components/schemas/Project"
           },
           "establishment": {
             "nullable": true,

--- a/src/Core/Dfe.Complete.Application/Projects/Models/ListAllProjectsQueryModel.cs
+++ b/src/Core/Dfe.Complete.Application/Projects/Models/ListAllProjectsQueryModel.cs
@@ -2,4 +2,4 @@
 
 namespace Dfe.Complete.Application.Projects.Models;
 
-public record ListAllProjectsQueryModel(Project? Project, GiasEstablishment? Establishment);
+public record ListAllProjectsQueryModel(Project Project, GiasEstablishment? Establishment);

--- a/src/Core/Dfe.Complete.Application/Projects/Queries/CountAllProjects/CountAllProjects.cs
+++ b/src/Core/Dfe.Complete.Application/Projects/Queries/CountAllProjects/CountAllProjects.cs
@@ -6,7 +6,11 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Dfe.Complete.Application.Projects.Queries.CountAllProjects
 {
-    public record CountAllProjectsQuery(ProjectState? ProjectStatus, ProjectType? Type, string? Search = "") : IRequest<Result<int>>;
+    public record CountAllProjectsQuery(
+        ProjectState? ProjectStatus,
+        ProjectType? Type,
+        AssignedToState? AssignedToState = null,
+        string? Search = "") : IRequest<Result<int>>;
 
     public class CountAllProjectsQueryHandler(
         IListAllProjectsQueryService listAllProjectsQueryService)
@@ -16,16 +20,10 @@ namespace Dfe.Complete.Application.Projects.Queries.CountAllProjects
         {
             try
             {
-                var projectsQuery = await listAllProjectsQueryService
-                    .ListAllProjects(request.ProjectStatus, request.Type, search: request.Search)
-                    .ToListAsync(cancellationToken);
-                
-                var filteredProjectQuery = request.ProjectStatus == ProjectState.Active
-                    ? projectsQuery.Where(p => p.Project?.AssignedTo != null)
-                    : projectsQuery;
-                
-                var result = filteredProjectQuery.Count();
-                
+                var result = await listAllProjectsQueryService
+                    .ListAllProjects(request.ProjectStatus, request.Type, search: request.Search, assignedToState: request.AssignedToState)
+                    .CountAsync(cancellationToken);
+
                 return Result<int>.Success(result);
             }
             catch (Exception ex)

--- a/src/Core/Dfe.Complete.Application/Projects/Queries/ListAllProjects/ListAllProjects.cs
+++ b/src/Core/Dfe.Complete.Application/Projects/Queries/ListAllProjects/ListAllProjects.cs
@@ -25,16 +25,13 @@ namespace Dfe.Complete.Application.Projects.Queries.ListAllProjects
             {
                 var projectList = await listAllProjectsQueryService
                     .ListAllProjects(request.ProjectStatus, request.Type, assignedToState: request.AssignedToState)
-                    .ToListAsync(cancellationToken);
-
-                var result = projectList
                     .Skip(request.Page * request.Count).Take(request.Count)
                     .Select(item => ListAllProjectsResultModel.MapProjectAndEstablishmentToListAllProjectResultModel(
                         item.Project!,
                         item.Establishment
                     ))
-                    .ToList();
-                return Result<List<ListAllProjectsResultModel>>.Success(result);
+                    .ToListAsync(cancellationToken);
+                return Result<List<ListAllProjectsResultModel>>.Success(projectList);
             }
             catch (Exception ex)
             {

--- a/src/Core/Dfe.Complete.Application/Projects/Queries/ListAllProjects/ListAllProjects.cs
+++ b/src/Core/Dfe.Complete.Application/Projects/Queries/ListAllProjects/ListAllProjects.cs
@@ -10,6 +10,7 @@ namespace Dfe.Complete.Application.Projects.Queries.ListAllProjects
     public record ListAllProjectsQuery(
         ProjectState? ProjectStatus,
         ProjectType? Type,
+        AssignedToState? AssignedToState = null,
         int Page = 0,
         int Count = 20) : IRequest<Result<List<ListAllProjectsResultModel>>>;
 
@@ -23,14 +24,10 @@ namespace Dfe.Complete.Application.Projects.Queries.ListAllProjects
             try
             {
                 var projectList = await listAllProjectsQueryService
-                    .ListAllProjects(request.ProjectStatus, request.Type)
+                    .ListAllProjects(request.ProjectStatus, request.Type, assignedToState: request.AssignedToState)
                     .ToListAsync(cancellationToken);
 
-                var filteredProjectList = request.ProjectStatus == ProjectState.Active
-                    ? projectList.Where(p => p.Project?.AssignedTo != null)
-                    : projectList;
-
-                var result = filteredProjectList
+                var result = projectList
                     .Skip(request.Page * request.Count).Take(request.Count)
                     .Select(item => ListAllProjectsResultModel.MapProjectAndEstablishmentToListAllProjectResultModel(
                         item.Project!,

--- a/src/Core/Dfe.Complete.Application/Projects/Queries/ListAllProjects/ListAllProjectsForLocalAuthority.cs
+++ b/src/Core/Dfe.Complete.Application/Projects/Queries/ListAllProjects/ListAllProjectsForLocalAuthority.cs
@@ -22,17 +22,19 @@ public class ListAllProjectsForLocalAuthority(IListAllProjectsQueryService listA
         try
         {
             var orderBy = new OrderProjectQueryBy();
-            var projectsForLa = await listAllProjectsQueryService.ListAllProjects(request.State, request.Type, localAuthorityCode: request.LocalAuthorityCode, orderBy: orderBy).ToListAsync(cancellationToken);
+            var projectsForLaQuery = listAllProjectsQueryService.ListAllProjects(request.State, request.Type, localAuthorityCode: request.LocalAuthorityCode, orderBy: orderBy);
 
-            var paginatedResultModel = projectsForLa.Select(proj =>
+            var count = await projectsForLaQuery.CountAsync(cancellationToken);
+
+            var paginatedResultModel = await projectsForLaQuery.Select(proj =>
                     ListAllProjectsResultModel.MapProjectAndEstablishmentToListAllProjectResultModel(
                         proj.Project,
                         proj.Establishment))
                 .Skip(request.Page * request.Count)
                 .Take(request.Count)
-                .ToList();
+                .ToListAsync(cancellationToken);
 
-            return PaginatedResult<List<ListAllProjectsResultModel>>.Success(paginatedResultModel, projectsForLa.Count);
+            return PaginatedResult<List<ListAllProjectsResultModel>>.Success(paginatedResultModel, count);
         }
         catch (Exception e)
         {

--- a/src/Core/Dfe.Complete.Application/Projects/Queries/ListAllProjects/ListAllProjectsForRegion.cs
+++ b/src/Core/Dfe.Complete.Application/Projects/Queries/ListAllProjects/ListAllProjectsForRegion.cs
@@ -26,19 +26,19 @@ public class ListAllProjectsForRegionQueryHandler(
     {
         try
         {
-            var projectsForRegion = await listAllProjectsQueryService.ListAllProjects(
-                request.ProjectStatus, request.Type, request.AssignedToState, region: request.Region, orderBy: request.OrderBy)
-                .ToListAsync(cancellationToken);
+            var projectsForRegionQuery = listAllProjectsQueryService.ListAllProjects(
+                request.ProjectStatus, request.Type, request.AssignedToState, region: request.Region, orderBy: request.OrderBy);
 
-            var paginatedResultModel = projectsForRegion.Select(proj =>
+            var count = await projectsForRegionQuery.CountAsync(cancellationToken);
+
+            var paginatedResultModel = await projectsForRegionQuery.Select(proj =>
                     ListAllProjectsResultModel.MapProjectAndEstablishmentToListAllProjectResultModel(proj.Project,
                         proj.Establishment))
                 .Skip(request.Page * request.Count)
                 .Take(request.Count)
-                .ToList();
+                .ToListAsync(cancellationToken);
 
-            return PaginatedResult<List<ListAllProjectsResultModel>>.Success(paginatedResultModel,
-                projectsForRegion.Count);
+            return PaginatedResult<List<ListAllProjectsResultModel>>.Success(paginatedResultModel, count);
         }
         catch (Exception e)
         {

--- a/src/Core/Dfe.Complete.Application/Projects/Queries/ListAllProjects/ListAllProjectsForTeam.cs
+++ b/src/Core/Dfe.Complete.Application/Projects/Queries/ListAllProjects/ListAllProjectsForTeam.cs
@@ -24,16 +24,18 @@ public class ListAllProjectsForTeamQueryHandler(IListAllProjectsQueryService lis
     {
         try
         {
-            var projectsForTeam = await listAllProjectsQueryService.ListAllProjects(
-                request.ProjectStatus, request.Type, request.AssignedToState, team: request.Team, orderBy: request.OrderBy).ToListAsync(cancellationToken);
+            var projectsForTeamQuery = listAllProjectsQueryService.ListAllProjects(
+                request.ProjectStatus, request.Type, request.AssignedToState, team: request.Team, orderBy: request.OrderBy);
 
-            var paginatedResultModel = projectsForTeam.Select(proj =>
-                    ListAllProjectsResultModel.MapProjectAndEstablishmentToListAllProjectResultModel(proj.Project!, proj.Establishment))
+            var count = await projectsForTeamQuery.CountAsync(cancellationToken);
+
+            var paginatedResultModel = await projectsForTeamQuery.Select(proj =>
+                    ListAllProjectsResultModel.MapProjectAndEstablishmentToListAllProjectResultModel(proj.Project, proj.Establishment))
                 .Skip(request.Page * request.Count)
                 .Take(request.Count)
-                .ToList();
+                .ToListAsync(cancellationToken);
 
-            return PaginatedResult<List<ListAllProjectsResultModel>>.Success(paginatedResultModel, projectsForTeam.Count);
+            return PaginatedResult<List<ListAllProjectsResultModel>>.Success(paginatedResultModel, count);
         }
         catch (Exception e)
         {

--- a/src/Core/Dfe.Complete.Application/Projects/Queries/ListAllProjects/ListAllProjectsForTeamHandover.cs
+++ b/src/Core/Dfe.Complete.Application/Projects/Queries/ListAllProjects/ListAllProjectsForTeamHandover.cs
@@ -24,19 +24,19 @@ public class ListAllProjectsForTeamHandoverQueryHandler(
     {
         try
         {
-            var projectsHandedOverForTeam = await listAllProjectsQueryService.ListAllProjects(
-                request.ProjectStatus, request.Type, region: request.Region, team: ProjectTeam.RegionalCaseWorkerServices)
-                .ToListAsync(cancellationToken);
+            var projectsHandedOverForTeamQuery = listAllProjectsQueryService.ListAllProjects(
+                request.ProjectStatus, request.Type, region: request.Region, team: ProjectTeam.RegionalCaseWorkerServices);
 
-            var paginatedResultModel = projectsHandedOverForTeam.Select(proj =>
+            var count = await projectsHandedOverForTeamQuery.CountAsync(cancellationToken);
+
+            var paginatedResultModel = await projectsHandedOverForTeamQuery.Select(proj =>
                     ListAllProjectsResultModel.MapProjectAndEstablishmentToListAllProjectResultModel(proj.Project,
                         proj.Establishment))
                 .Skip(request.Page * request.Count)
                 .Take(request.Count)
-                .ToList();
+                .ToListAsync(cancellationToken);
 
-            return PaginatedResult<List<ListAllProjectsResultModel>>.Success(paginatedResultModel,
-                projectsHandedOverForTeam.Count);
+            return PaginatedResult<List<ListAllProjectsResultModel>>.Success(paginatedResultModel, count);
         }
         catch (Exception e)
         {

--- a/src/Core/Dfe.Complete.Application/Projects/Queries/ListAllProjects/ListProjectsByMonths.cs
+++ b/src/Core/Dfe.Complete.Application/Projects/Queries/ListAllProjects/ListProjectsByMonths.cs
@@ -28,7 +28,7 @@ namespace Dfe.Complete.Application.Projects.Queries.ListProjectsByMonth
             try
             {
                 var projectsQuery = listAllProjectsQueryService
-                    .ListAllProjects(request.ProjectStatus, request.Type)
+                    .ListAllProjects(request.ProjectStatus, request.Type, assignedToState: AssignedToState.AssignedOnly)
                     .AsEnumerable();
 
                 if (request.ToDate.HasValue)
@@ -46,7 +46,7 @@ namespace Dfe.Complete.Application.Projects.Queries.ListProjectsByMonth
                         p.Project.SignificantDate.Value == request.FromDate);
                 }
 
-                var projects = projectsQuery.Where(p => p.Project.SignificantDateProvisional == false && p.Project.AssignedTo != null).ToList(); // Confirmed && Inprogress
+                var projects = projectsQuery.Where(p => p.Project.SignificantDateProvisional == false).ToList(); // Confirmed && Inprogress
 
                 var ukprns = projects.Select(p => p.Project.IncomingTrustUkprn?.Value.ToString()).ToList();
                 var outgoingTrustUkprns = projects.Where(p => p.Project.OutgoingTrustUkprn != null).Select(p => p.Project.OutgoingTrustUkprn.Value.ToString()).ToList();

--- a/src/Frontend/Dfe.Complete/Pages/Projects/List/CompletedProjects/AllCompletedProjects.cshtml.cs
+++ b/src/Frontend/Dfe.Complete/Pages/Projects/List/CompletedProjects/AllCompletedProjects.cshtml.cs
@@ -19,7 +19,7 @@ public class AllCompletedProjectsViewModel(ISender sender) : AllProjectsModel(Co
     {
         ViewData[TabNavigationModel.ViewDataKey] = AllProjectsTabNavigationModel;
 
-        var listProjectQuery = new ListAllProjectsQuery(ProjectState.Completed, null, PageNumber - 1, PageSize);
+        var listProjectQuery = new ListAllProjectsQuery(ProjectState.Completed, null, null, PageNumber - 1, PageSize);
 
         var listResponse = await sender.Send(listProjectQuery);
         Projects = (listResponse.Value ?? [])

--- a/src/Frontend/Dfe.Complete/Pages/Projects/List/ProjectsInProgress/AllProjectsInProgress.cshtml.cs
+++ b/src/Frontend/Dfe.Complete/Pages/Projects/List/ProjectsInProgress/AllProjectsInProgress.cshtml.cs
@@ -15,12 +15,12 @@ namespace Dfe.Complete.Pages.Projects.List.ProjectsInProgress
         public async Task OnGet()
         {
             ViewData[TabNavigationModel.ViewDataKey] = AllProjectsTabNavigationModel;
-            
-            var listProjectQuery = new ListAllProjectsQuery(ProjectState.Active, null, PageNumber-1, PageSize);
+
+            var listProjectQuery = new ListAllProjectsQuery(ProjectState.Active, null, AssignedToState.AssignedOnly, PageNumber - 1, PageSize);
 
             var listResponse = await sender.Send(listProjectQuery);
             Projects = listResponse.Value ?? [];
-            
+
             var countProjectQuery = new CountAllProjectsQuery(ProjectState.Active, null);
             var countResponse = await sender.Send(countProjectQuery);
 

--- a/src/Frontend/Dfe.Complete/Pages/Projects/List/ProjectsInProgress/AllProjectsInProgress.cshtml.cs
+++ b/src/Frontend/Dfe.Complete/Pages/Projects/List/ProjectsInProgress/AllProjectsInProgress.cshtml.cs
@@ -21,7 +21,7 @@ namespace Dfe.Complete.Pages.Projects.List.ProjectsInProgress
             var listResponse = await sender.Send(listProjectQuery);
             Projects = listResponse.Value ?? [];
 
-            var countProjectQuery = new CountAllProjectsQuery(ProjectState.Active, null);
+            var countProjectQuery = new CountAllProjectsQuery(ProjectState.Active, null, AssignedToState.AssignedOnly);
             var countResponse = await sender.Send(countProjectQuery);
 
             Pagination = new PaginationModel("/projects/all/in-progress/all", PageNumber, countResponse.Value, PageSize);

--- a/src/Frontend/Dfe.Complete/Pages/Projects/List/ProjectsInProgress/ConversionProjectsInProgress.cshtml.cs
+++ b/src/Frontend/Dfe.Complete/Pages/Projects/List/ProjectsInProgress/ConversionProjectsInProgress.cshtml.cs
@@ -17,7 +17,7 @@ public class ConversionProjectsInProgressModel(ISender sender) : ConversionOrTra
         var response = await sender.Send(listProjectQuery);
         Projects = response.Value?.ToList() ?? [];
 
-        var countProjectQuery = new CountAllProjectsQuery(ProjectState.Active, ProjectType.Conversion);
+        var countProjectQuery = new CountAllProjectsQuery(ProjectState.Active, ProjectType.Conversion, AssignedToState.AssignedOnly);
         var countResponse = await sender.Send(countProjectQuery);
 
         Pagination = new PaginationModel("/projects/all/in-progress/conversions", PageNumber, countResponse.Value, PageSize);

--- a/src/Frontend/Dfe.Complete/Pages/Projects/List/ProjectsInProgress/ConversionProjectsInProgress.cshtml.cs
+++ b/src/Frontend/Dfe.Complete/Pages/Projects/List/ProjectsInProgress/ConversionProjectsInProgress.cshtml.cs
@@ -12,7 +12,7 @@ public class ConversionProjectsInProgressModel(ISender sender) : ConversionOrTra
     public async Task OnGet()
     {
         ViewData[TabNavigationModel.ViewDataKey] = AllProjectsTabNavigationModel;
-        var listProjectQuery = new ListAllProjectsQuery(ProjectState.Active, ProjectType.Conversion, PageNumber - 1, PageSize);
+        var listProjectQuery = new ListAllProjectsQuery(ProjectState.Active, ProjectType.Conversion, AssignedToState.AssignedOnly, PageNumber - 1, PageSize);
 
         var response = await sender.Send(listProjectQuery);
         Projects = response.Value?.ToList() ?? [];

--- a/src/Frontend/Dfe.Complete/Pages/Projects/List/ProjectsInProgress/TransferProjectsInProgress.cshtml.cs
+++ b/src/Frontend/Dfe.Complete/Pages/Projects/List/ProjectsInProgress/TransferProjectsInProgress.cshtml.cs
@@ -17,7 +17,7 @@ public class TransferProjectsInProgressModel(ISender sender) : ConversionOrTrans
         var response = await sender.Send(listProjectQuery);
         Projects = response.Value?.ToList() ?? [];
 
-        var countProjectQuery = new CountAllProjectsQuery(ProjectState.Active, ProjectType.Transfer);
+        var countProjectQuery = new CountAllProjectsQuery(ProjectState.Active, ProjectType.Transfer, AssignedToState.AssignedOnly);
         var countResponse = await sender.Send(countProjectQuery);
 
         Pagination = new PaginationModel("/projects/all/in-progress/transfers", PageNumber, countResponse.Value, PageSize);

--- a/src/Frontend/Dfe.Complete/Pages/Projects/List/ProjectsInProgress/TransferProjectsInProgress.cshtml.cs
+++ b/src/Frontend/Dfe.Complete/Pages/Projects/List/ProjectsInProgress/TransferProjectsInProgress.cshtml.cs
@@ -12,7 +12,7 @@ public class TransferProjectsInProgressModel(ISender sender) : ConversionOrTrans
     public async Task OnGet()
     {
         ViewData[TabNavigationModel.ViewDataKey] = AllProjectsTabNavigationModel;
-        var listProjectQuery = new ListAllProjectsQuery(ProjectState.Active, ProjectType.Transfer, PageNumber - 1, PageSize);
+        var listProjectQuery = new ListAllProjectsQuery(ProjectState.Active, ProjectType.Transfer, AssignedToState.AssignedOnly, PageNumber - 1, PageSize);
 
         var response = await sender.Send(listProjectQuery);
         Projects = response.Value?.ToList() ?? [];

--- a/src/Frontend/Dfe.Complete/Pages/Search/SearchProjects.cshtml.cs
+++ b/src/Frontend/Dfe.Complete/Pages/Search/SearchProjects.cshtml.cs
@@ -15,7 +15,7 @@ namespace Dfe.Complete.Pages.Search
         public string Query { get; set; } = string.Empty;
 
         public List<ListAllProjectsResultModel> Projects { get; set; } = default!;
-         
+
         public string ErrorMessage { get; set; } = string.Empty;
 
         public int TotalResults { get; set; } = 0;
@@ -26,17 +26,17 @@ namespace Dfe.Complete.Pages.Search
             {
                 ErrorMessage = "Please enter a search term";
             }
-            else if(Query.Length < 4 )
+            else if (Query.Length < 4)
             {
                 ErrorMessage = "Search term too short";
             }
-            else if(IsMixedString(Query))
+            else if (IsMixedString(Query))
             {
                 Projects = [];
             }
             else
             {
-                var countProjectQuery = new CountAllProjectsQuery(ProjectState.Active, null, Query);
+                var countProjectQuery = new CountAllProjectsQuery(ProjectState.Active, null, AssignedToState.AssignedOnly, Query);
                 var countResponse = await sender.Send(countProjectQuery);
 
                 var searchProjectsQuery = new SearchProjectsQuery(ProjectState.Active, Query)

--- a/src/Tests/Dfe.Complete.Api.Tests.Integration/Controllers/ProjectsController/ProjectsControllerTests.cs
+++ b/src/Tests/Dfe.Complete.Api.Tests.Integration/Controllers/ProjectsController/ProjectsControllerTests.cs
@@ -59,7 +59,7 @@ public partial class ProjectsControllerTests
         await dbContext.Projects.AddRangeAsync(projects);
         await dbContext.SaveChangesAsync();
 
-        var result = await projectsClient.CountAllProjectsAsync(null, null, null);
+        var result = await projectsClient.CountAllProjectsAsync(null, null, null, null);
 
         Assert.Equal(50, result);
     }
@@ -103,7 +103,7 @@ public partial class ProjectsControllerTests
 
         // Act
         var results = await projectsClient.ListAllProjectsAsync(
-            null, null, 0, 50);
+            null, null, null, 0, 50);
 
         // Assert
         Assert.NotNull(results);
@@ -178,7 +178,7 @@ public partial class ProjectsControllerTests
 
         // Act
         var results = await projectsClient.ListAllProjectsAsync(
-            ProjectState.Completed, null, 0, 50);
+            ProjectState.Completed, null, null, 0, 50);
 
         // Assert
         Assert.NotNull(results);

--- a/src/Tests/Dfe.Complete.Application.Tests/QueryHandlers/Project/CountAllProjectsQueryHandlerTests.cs
+++ b/src/Tests/Dfe.Complete.Application.Tests/QueryHandlers/Project/CountAllProjectsQueryHandlerTests.cs
@@ -13,7 +13,6 @@ namespace Dfe.Complete.Application.Tests.QueryHandlers.Project
 {
     public class CountAllProjectsQueryHandlerTests
     {
-
         [Theory]
         [CustomAutoData(
             typeof(OmitCircularReferenceCustomization),
@@ -28,10 +27,11 @@ namespace Dfe.Complete.Application.Tests.QueryHandlers.Project
             // Arrange
             var expected = listAllProjectsQueryModels.Count;
 
-            var mock = listAllProjectsQueryModels.BuildMock();
+            var mockQueryable = listAllProjectsQueryModels.AsQueryable().BuildMock();
 
-            mockListAllProjectsQueryService.ListAllProjects(query.ProjectStatus, query.Type, search: query.Search)
-                .Returns(mock);
+            mockListAllProjectsQueryService
+                .ListAllProjects(query.ProjectStatus, query.Type, search: query.Search, assignedToState: query.AssignedToState)
+                .Returns(mockQueryable);
 
             // Act
             var result = await handler.Handle(query, default);
@@ -39,7 +39,6 @@ namespace Dfe.Complete.Application.Tests.QueryHandlers.Project
             // Assert
             Assert.Equal(expected, result.Value);
         }
-
         [Theory]
         [CustomAutoData(
             typeof(OmitCircularReferenceCustomization),

--- a/src/Tests/Dfe.Complete.Application.Tests/QueryHandlers/Project/ListAllProjectsByMonthHandlerTests.cs
+++ b/src/Tests/Dfe.Complete.Application.Tests/QueryHandlers/Project/ListAllProjectsByMonthHandlerTests.cs
@@ -28,7 +28,7 @@ public class ListAllProjectsByMonthHandlerTests
         var errorMessage = "This is a test";
 
         mockListAllProjectsQueryService
-            .ListAllProjects(Arg.Any<ProjectState?>(), Arg.Any<ProjectType?>())
+            .ListAllProjects(Arg.Any<ProjectState?>(), Arg.Any<ProjectType?>(), assignedToState: Arg.Any<AssignedToState>())
             .Throws(new Exception(errorMessage));
 
         var date = DateOnly.FromDateTime(DateTime.Today);
@@ -98,7 +98,7 @@ public class ListAllProjectsByMonthHandlerTests
             })
             .BuildMock();
         
-        mockListAllProjectsQueryService.ListAllProjects(Arg.Any<ProjectState?>(), Arg.Any<ProjectType?>()).Returns(listAllProjectsQueryModels);
+        mockListAllProjectsQueryService.ListAllProjects(Arg.Any<ProjectState?>(), Arg.Any<ProjectType?>(), assignedToState: Arg.Any<AssignedToState>()).Returns(listAllProjectsQueryModels);
         
         var trustDtos = fixture
             .Build<TrustDto>()
@@ -164,7 +164,7 @@ public class ListAllProjectsByMonthHandlerTests
 
         var final = projects.BuildMock();
 
-        mockListAllProjectsQueryService.ListAllProjects(Arg.Any<ProjectState?>(), Arg.Any<ProjectType?>()).Returns(final);
+        mockListAllProjectsQueryService.ListAllProjects(Arg.Any<ProjectState?>(), Arg.Any<ProjectType?>(), assignedToState: Arg.Any<AssignedToState>()).Returns(final);
         
         // Act
         var result = await handler.Handle(new ListProjectsByMonthsQuery(startDate, endDate, ProjectState.Active, ProjectType.Conversion), default);

--- a/src/Tests/Dfe.Complete.Application.Tests/QueryHandlers/Project/ListAllProjectsQueryHandlerTests.cs
+++ b/src/Tests/Dfe.Complete.Application.Tests/QueryHandlers/Project/ListAllProjectsQueryHandlerTests.cs
@@ -70,7 +70,7 @@ public class ListAllProjectsQueryHandlerTests
                 item.Establishment
             )).Skip(20).Take(20).ToList();
 
-        var query = new ListAllProjectsQuery(null, null, 1);
+        var query = new ListAllProjectsQuery(null, null, null, 1);
 
         var mock = listAllProjectsQueryModels.BuildMock();
 
@@ -122,7 +122,7 @@ public class ListAllProjectsQueryHandlerTests
 
         var mock = combinedProjects.BuildMock();
 
-        var query = new ListAllProjectsQuery(ProjectState.Active, ProjectType.Conversion);
+        var query = new ListAllProjectsQuery(ProjectState.Active, ProjectType.Conversion, AssignedToState.AssignedOnly);
 
         mockListAllProjectsQueryService.ListAllProjects(query.ProjectStatus, query.Type)
             .Returns(mock);
@@ -152,7 +152,7 @@ public class ListAllProjectsQueryHandlerTests
         // Arrange
         var listAllProjectsQueryModels = fixture.CreateMany<ListAllProjectsQueryModel>(50).ToList();
 
-        var query = new ListAllProjectsQuery(null, null, 10);
+        var query = new ListAllProjectsQuery(null, null, null, 10);
 
         var mock = listAllProjectsQueryModels.BuildMock();
 

--- a/src/Tests/Dfe.Complete.Application.Tests/QueryHandlers/Project/ListAllProjectsQueryHandlerTests.cs
+++ b/src/Tests/Dfe.Complete.Application.Tests/QueryHandlers/Project/ListAllProjectsQueryHandlerTests.cs
@@ -95,55 +95,6 @@ public class ListAllProjectsQueryHandlerTests
         typeof(OmitCircularReferenceCustomization),
         typeof(ListAllProjectsQueryModelCustomization),
         typeof(DateOnlyCustomization))]
-    public async Task Handle_ShouldOnlyReturnProjectsThatAreAssigned(
-        [Frozen] IListAllProjectsQueryService mockListAllProjectsQueryService,
-        ListAllProjectsQueryHandler handler,
-        IFixture fixture)
-    {
-        // Arrange
-        var totalProjects = 15;
-        var expectedProjects = 10;
-
-        var combinedProjects = fixture.CreateMany<ListAllProjectsQueryModel>(totalProjects).ToList();
-
-        // Set first 10 as assigned, last 5 as unassigned
-        for (int i = 0; i < combinedProjects.Count; i++)
-        {
-            if (i < 10)
-            {
-                combinedProjects[i].Project!.AssignedTo = fixture.Create<Domain.Entities.User>();
-            }
-            else
-            {
-                combinedProjects[i].Project!.AssignedTo = null;
-            }
-        }
-
-
-        var mock = combinedProjects.BuildMock();
-
-        var query = new ListAllProjectsQuery(ProjectState.Active, ProjectType.Conversion, AssignedToState.AssignedOnly);
-
-        mockListAllProjectsQueryService.ListAllProjects(query.ProjectStatus, query.Type)
-            .Returns(mock);
-
-        // Act
-        var result = await handler.Handle(query, default);
-
-        // Assert
-        Assert.NotNull(result);
-        Assert.True(result.IsSuccess);
-        Assert.All(result.Value!, project =>
-            Assert.False(string.IsNullOrWhiteSpace(project.AssignedToFullName)));
-        Assert.Equal(expectedProjects, result.Value!.Count);
-    }
-
-
-    [Theory]
-    [CustomAutoData(
-        typeof(OmitCircularReferenceCustomization),
-        typeof(ListAllProjectsQueryModelCustomization),
-        typeof(DateOnlyCustomization))]
     public async Task Handle_ShouldReturnCorrectList_WhenAllPagesAreSkipped(
         [Frozen] IListAllProjectsQueryService mockListAllProjectsQueryService,
         ListAllProjectsQueryHandler handler,


### PR DESCRIPTION
- Moved `ToListAsync` after paginations in most of the query that use `ListAllProjectsQuery`
- In some cases, I had to delegate the `AssignedToState` filtering the the `ListAllProjectsQuery` - which is the correct way to do it anyway

Optimised quite a lot of queries. Some pages were taking up to 10 seconds to load on TEST. This is down to less than a second, sometimes still noticeable but much improved