### PR TITLE
show not yet assigned text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Security in case of vulnerabilities.
 - Navigation items previously hidden with `UserTabAccessHelper` now hide on policy
 
 ### Fixed  
+- Unassigned projects should show "Not yet assigned" under "Assigned To" column for projects on the local authority/trust pages
 
 ### Removed
 - `UserTabAccessHelper` class is no longer required. Use policies instead

--- a/src/Frontend/Dfe.Complete/Pages/Projects/List/ProjectsByLocalAuthority/ProjectsForLocalAuthority.cshtml
+++ b/src/Frontend/Dfe.Complete/Pages/Projects/List/ProjectsByLocalAuthority/ProjectsForLocalAuthority.cshtml
@@ -38,7 +38,7 @@
             <td class="govuk-table__cell">@project.Urn.Value</td>
             <td class="govuk-table__cell">@project.ConversionOrTransferDate.ToMonthYearString()</td>
             <td class="govuk-table__cell">@project.ProjectType</td>
-            <td class="govuk-table__cell">@project.AssignedToFullName</td>
+            <td class="govuk-table__cell">@(project.AssignedToFullName ?? "Not yet assigned")</td>
         </tr>
         }
         </tbody>

--- a/src/Frontend/Dfe.Complete/Pages/Projects/List/ProjectsByTrust/_ProjectsTable.cshtml
+++ b/src/Frontend/Dfe.Complete/Pages/Projects/List/ProjectsByTrust/_ProjectsTable.cshtml
@@ -25,7 +25,7 @@
         <td class="govuk-table__cell">@project.Urn.Value</td>
         <td class="govuk-table__cell">@project.ConversionOrTransferDate.ToMonthYearString()</td>
         <td class="govuk-table__cell">@project.ProjectType</td>
-        <td class="govuk-table__cell">@project.AssignedToFullName</td>
+        <td class="govuk-table__cell">@(project.AssignedToFullName ?? "Not yet assigned")</td>
       </tr>
     }
     </tbody>


### PR DESCRIPTION
## Ticket(s)

Resolves two bug tickets:
[local authority not showing "Not yet assigned](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/Dot%20Net/Stories?System.IterationPath=Academies-and-Free-Schools-SIP%5CDot%20NET%20sprints%5CDot%20net%20Q1%20Sprint%204&workitem=216554)
[trust not showing "Not yet assigned](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_boards/board/t/Dot%20Net/Stories?System.IterationPath=Academies-and-Free-Schools-SIP%5CDot%20NET%20sprints%5CDot%20net%20Q1%20Sprint%204&workitem=216541)

## Description

Show "Not yet assigned" text