### PR TITLE
Add tests for conversion task 

### DIFF
--- a/src/Tests/Dfe.Complete.CypressTests/cypress/e2e/projects/conversion/tasks/conversion-handover-with-delivery-officer-task.cy.ts
+++ b/src/Tests/Dfe.Complete.CypressTests/cypress/e2e/projects/conversion/tasks/conversion-handover-with-delivery-officer-task.cy.ts
@@ -1,0 +1,115 @@
+import conversionHandoverWithDeliveryOfficerTaskPage from 'cypress/pages/projects/conversionHandoverWithDeliveryOfficerTaskPage';
+import { ProjectBuilder } from "cypress/api/projectBuilder";
+import projectApi from "cypress/api/projectApi";
+import { checkAccessibilityAcrossPages } from "cypress/support/reusableTests";
+import taskListPage from 'cypress/pages/projects/taskListPage';
+
+const project = ProjectBuilder.createConversionFormAMatProjectRequest();
+let projectId: string;
+
+describe('Conversion Handover With Delivery Officer Task Page', () => {
+    before(() => {
+        projectApi.createMatConversionProject(project).then((response) => (projectId = response.value));
+    });
+
+    beforeEach(() => {
+        cy.login();
+        cy.acceptCookies();
+        cy.visit(`projects/${projectId}/tasks`);
+        taskListPage
+            .selectTask('Handover with regional delivery officer')
+    });
+
+    it('should display all checkboxes with correct labels and hints', () => {
+        conversionHandoverWithDeliveryOfficerTaskPage.getCheckboxLabel('not-applicable').should('contain', 'Not applicable');
+        conversionHandoverWithDeliveryOfficerTaskPage.getCheckboxLabel('conversion_task_handover_task_form_review').should('contain', 'Review the project information');
+        conversionHandoverWithDeliveryOfficerTaskPage.getCheckboxLabel('conversion_task_handover_task_form_notes').should('contain', 'Make notes and write questions');
+        conversionHandoverWithDeliveryOfficerTaskPage.getCheckboxLabel('conversion_task_handover_task_form_meeting').should('contain', 'Attend handover meeting');
+    });
+
+    it('should expand and collapse guidance details', () => {
+        conversionHandoverWithDeliveryOfficerTaskPage.expandGuidance('What to check for');
+        conversionHandoverWithDeliveryOfficerTaskPage.getGuidanceContent('You should check existing project documents').should('be.visible');
+        conversionHandoverWithDeliveryOfficerTaskPage.expandGuidance('What to make notes about');
+        conversionHandoverWithDeliveryOfficerTaskPage.getGuidanceContent('Note down things you want to ask').should('be.visible');
+    });
+
+    it('should display the school name in the caption', () => {
+        conversionHandoverWithDeliveryOfficerTaskPage.getSchoolName().should('be.visible');
+    });
+
+    it('should submit the form with Save and return', () => { //save is not working atm on Dev
+        conversionHandoverWithDeliveryOfficerTaskPage.saveAndReturn();
+        cy.url().should('not.include', 'handover-with-delivery-officer');
+    });
+
+    it('should display a working back link', () => {  //back link not working atm
+        cy.get('a.govuk-back-link').should('be.visible').and('contain', 'Back');
+        conversionHandoverWithDeliveryOfficerTaskPage.clickBackLink();
+        cy.url().should('not.include', 'handover-with-delivery-officer');
+    });
+
+    it('should show task status based on the checkboxes are checked', () => {
+        // Check not applicable checkboxes
+        conversionHandoverWithDeliveryOfficerTaskPage
+            .selectButtonOrCheckbox('not-applicable')
+            .saveAndReturn()
+        taskListPage
+            .hasTaskStatusNotApplicable('handover-with-delivery-officer-status')
+        conversionHandoverWithDeliveryOfficerTaskPage
+            .selectButtonOrCheckbox('conversion_task_handover_task_form_review')
+            .saveAndReturn()
+        taskListPage
+            .hasTaskStatusCompleted('handover-with-delivery-officer-status')
+        conversionHandoverWithDeliveryOfficerTaskPage
+            .selectButtonOrCheckbox('not-applicable')
+            .selectButtonOrCheckbox('conversion_task_handover_task_form_notes')
+            .selectButtonOrCheckbox('conversion_task_handover_task_form_meeting')
+            .saveAndReturn()
+        taskListPage
+            .hasTaskStatusCompleted('handover-with-delivery-officer-status')
+    })
+
+    it('should load the handover task list page within 2 seconds', () => {
+        const start = Date.now();
+        // cy.visit('/projects/PROJECT_ID/tasks'); // Replace PROJECT_ID as needed
+        cy.get('form').should('be.visible').then(() => {
+            const duration = Date.now() - start;
+            expect(duration).to.be.lessThan(2000);
+        });
+    });
+
+    it('should be able to nabigate back from the task page', () => {
+        cy.get('a.govuk-back-link').should('contain', 'Back')
+          .click();
+        // Assert that the URL changes to the expected task list page
+        cy.url().should('not.include', 'handover-task-list');
+    });
+
+    it('should display the Notes section on the handover with delivery officer task page', () => {
+        conversionHandoverWithDeliveryOfficerTaskPage.getNotesSection().should('exist').and('be.visible');
+    });
+
+    it('should allow the user to add a note', () => {
+        const note = `Test note by Cypress ${Date.now()}`;
+        conversionHandoverWithDeliveryOfficerTaskPage.addNote(note);
+        cy.contains(note).should('exist');
+    });
+
+    it('should allow the user to edit only their own notes', () => {
+        const originalNote = `Editable note by Cypress ${Date.now()}`;
+        const updatedNote = `Updated note by Cypress ${Date.now()}`;
+        // Add a note
+        conversionHandoverWithDeliveryOfficerTaskPage.addNote(originalNote);
+        cy.contains(originalNote).should('exist');
+        // Edit the note
+        conversionHandoverWithDeliveryOfficerTaskPage.editNote(originalNote, updatedNote);
+        cy.contains(updatedNote).should('exist');
+        // Optionally, check that edit button is not present for a note not created by this user
+        // conversionHandoverWithDeliveryOfficerTaskPage.cannotEditNote('Some other user\'s note');
+    });
+
+    it("Check accessibility across pages", () => {
+        checkAccessibilityAcrossPages();
+    });
+});

--- a/src/Tests/Dfe.Complete.CypressTests/cypress/e2e/projects/conversion/tasks/conversion-task-list-navigation.cy.ts
+++ b/src/Tests/Dfe.Complete.CypressTests/cypress/e2e/projects/conversion/tasks/conversion-task-list-navigation.cy.ts
@@ -1,0 +1,60 @@
+import conversionTaskListPage from 'cypress/pages/projects/conversionTaskListPage';
+import { ProjectBuilder } from "cypress/api/projectBuilder";
+import projectApi from "cypress/api/projectApi";
+
+const project = ProjectBuilder.createConversionFormAMatProjectRequest();
+let projectId: string;
+
+describe('Conversion Project Tasks List Navigation', () => {
+    before(() => {
+        projectApi.createMatConversionProject(project).then((response) => (projectId = response.value));
+    });
+
+    beforeEach(() => {
+        cy.login();
+        cy.acceptCookies();
+        conversionTaskListPage.visit(projectId);
+    });
+
+    it('should display all project kick-off tasks', () => {
+        conversionTaskListPage
+            .verifyTaskGroupExists('Project kick-off')
+            .verifyAllTasksInGroup(conversionTaskListPage.taskGroups.projectKickOff);
+    });
+
+    it('should display all legal documents tasks', () => {
+        conversionTaskListPage
+            .verifyTaskGroupExists('Clear and sign legal documents')
+            .verifyAllTasksInGroup(conversionTaskListPage.taskGroups.clearAndSignLegalDocuments);
+    });
+
+    it('should display all ready for opening tasks', () => {
+        conversionTaskListPage
+            .verifyTaskGroupExists('Get ready for opening')
+            .verifyAllTasksInGroup(conversionTaskListPage.taskGroups.getReadyForOpening);
+    });
+
+    it('should display all after opening tasks', () => {
+        conversionTaskListPage
+            .verifyTaskGroupExists('After opening')
+            .verifyAllTasksInGroup(conversionTaskListPage.taskGroups.afterOpening);
+    });
+
+    it('should allow navigation to each task', () => {
+        // Test navigation for one task from each group as an example
+        const tasksToTest = [
+            conversionTaskListPage.taskGroups.projectKickOff[0],
+            conversionTaskListPage.taskGroups.clearAndSignLegalDocuments[0],
+            conversionTaskListPage.taskGroups.getReadyForOpening[0],
+            conversionTaskListPage.taskGroups.afterOpening[0]
+        ];
+
+        tasksToTest.forEach(task => {
+            conversionTaskListPage.visit(projectId);
+            conversionTaskListPage.clickTask(task);
+            // Verify navigation by checking URL contains task name in kebab-case
+            const taskUrlPart = task.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+            cy.url().should('include', taskUrlPart); // need to adjust this based on actual URL structure
+        });
+    });
+});

--- a/src/Tests/Dfe.Complete.CypressTests/cypress/pages/projects/conversionHandoverWithDeliveryOfficerTaskPage.ts
+++ b/src/Tests/Dfe.Complete.CypressTests/cypress/pages/projects/conversionHandoverWithDeliveryOfficerTaskPage.ts
@@ -1,0 +1,82 @@
+class ConversionHandoverWithDeliveryOfficerTaskPage {
+    visit(projectId: string) {
+        cy.visit(`projects/${projectId}/tasks/handover-with-delivery-officer`);
+    }
+
+    getSchoolName() {
+        return cy.get('[data-testid="school-name"]');
+    }
+
+    getCheckbox(id: string) {
+        return cy.get(`input[id="${id}"]`);
+    }
+
+    getCheckboxLabel(id: string) {
+        return cy.get(`label[for="${id}"]`);
+    }
+
+    expandGuidance(summaryText: string) {
+        cy.contains('summary', summaryText).click();
+    }
+
+    getGuidanceContent(content: string) {
+        return cy.contains(content);
+    }
+
+    saveAndReturn() {
+        cy.get('.govuk-button').contains('Save and return').click();
+        cy.url().should('not.include', 'handover');
+    }
+
+    uncheckFirstCheckbox() {
+    cy.get('input[type="checkbox"]').first().uncheck({ force: true });
+  }
+
+    clickBackLink() {
+        cy.get('a.govuk-back-link').click();
+    }
+
+    public selectButtonOrCheckbox(id: string): this {
+        cy.getById(id).click();
+
+        return this;
+    }
+
+    // Notes section
+    getNotesSection() {
+        return cy.get('[data-testid="notes-section"], .notes-section, #notes-section'); // Adjust selector as needed
+    }
+
+    // Add note
+    addNote(note: string) {
+        cy.contains('Add a new task note').click();
+        cy.get('textarea').type(note);
+        cy.contains('Save').click();
+    }
+
+    // Edit note (by content)
+    editNote(existingNote: string, updatedNote: string) {
+        cy.contains(existingNote).parent().within(() => {
+            cy.contains('Edit note').click();
+        });
+        cy.get('textarea').clear().type(updatedNote);
+        cy.contains('Save').click();
+    }
+
+    // Check if edit button is present for a note
+    canEditNote(note: string) {
+        return cy.contains(note).parent().within(() => {
+            cy.contains('Edit note').should('exist');
+        });
+    }
+
+    // Check if edit button is not present for a note
+    cannotEditNote(note: string) {
+        return cy.contains(note).parent().within(() => {
+            cy.contains('Edit note').should('not.exist');
+        });
+    }
+}
+
+const conversionHandoverWithDeliveryOfficerTaskPage = new ConversionHandoverWithDeliveryOfficerTaskPage();
+export default conversionHandoverWithDeliveryOfficerTaskPage;

--- a/src/Tests/Dfe.Complete.CypressTests/cypress/pages/projects/conversionTaskListPage.ts
+++ b/src/Tests/Dfe.Complete.CypressTests/cypress/pages/projects/conversionTaskListPage.ts
@@ -1,0 +1,73 @@
+class ConversionTaskListPage {
+    taskGroups = {
+        projectKickOff: [
+            'Handover with regional delivery officer',
+            'External stakeholder kick-off',
+            'Check accuracy of high needs places information',
+            'Complete a notification of changes to funded high needs places form',
+            'Process conversion grant',
+            'Confirm and process the sponsored support grant',
+            'Confirm the academy name',
+            'Confirm the main contact',
+            'Add chair of governors\' contact details',
+            'Confirm the proposed capacity of the academy'
+        ],
+        clearAndSignLegalDocuments: [
+            'Land questionnaire',
+            'Land registry title plans',
+            'Supplemental funding agreement',
+            'Church supplemental agreement',
+            'Master funding agreement',
+            'Articles of association',
+            'Deed of variation',
+            'Trust modification order',
+            'Direction to transfer',
+            '125 year lease',
+            'Subleases',
+            'Tenancy at will',
+            'Commercial transfer agreement'
+        ],
+        getReadyForOpening: [
+            'Confirm the academy\'s risk protection arrangements',
+            'Complete and send single worksheet',
+            'Confirm the school has completed all actions',
+            'Confirm all conditions have been met',
+            'Share the grant certificate and information about opening'
+        ],
+        afterOpening: [
+            'Confirm the date the academy opened',
+            'Redact and send documents',
+            'Receive grant payment certificate'
+        ]
+    };
+
+    visit(projectId: string) {
+        cy.visit(`projects/${projectId}/tasks`);
+        return this;
+    }
+
+    verifyTaskGroupExists(groupName: string) {
+        cy.contains('h3', groupName).should('be.visible');
+        return this;
+    }
+
+    verifyTaskExists(taskName: string) {
+        cy.contains('a', taskName).should('be.visible');
+        return this;
+    }
+
+    verifyAllTasksInGroup(tasks: string[]) {
+        tasks.forEach(task => {
+            this.verifyTaskExists(task);
+        });
+        return this;
+    }
+
+    clickTask(taskName: string) {
+        cy.contains('a', taskName).click();
+        return this;
+    }
+}
+
+const conversionTaskListPage = new ConversionTaskListPage();
+export default conversionTaskListPage;

--- a/src/Tests/Dfe.Complete.CypressTests/cypress/pages/projects/taskListPage.ts
+++ b/src/Tests/Dfe.Complete.CypressTests/cypress/pages/projects/taskListPage.ts
@@ -6,6 +6,41 @@ class TaskListPage {
                 return new TaskSummary(element);
             });
     }
+
+     public hasTasks(): this {
+        cy.contains('Handover with regional delivery officer');
+        cy.contains('External stakeholder kick-off');
+
+        return this;
+    }
+
+    public selectTask(taskName: string) {
+        cy.contains(taskName).click();
+
+        return this;
+    }
+
+    public hasTasksNotStartedElementsPresent(): this {
+        cy.get("#confirm-eligibility-status").contains('Not Started');
+
+        return this;
+    }
+
+        public hasTaskStatusNotApplicable(id: string) {
+        cy.get(`#${id}`).contains("Not Applicabale");
+
+        return this;
+    }
+
+    public hasTaskStatusCompleted(id: string) {
+        cy.get(`#${id}`).contains("Completed");
+
+        return this;
+    }
+
+    public hasTaskStatusInProgress(id: string) {
+        cy.get(`#${id}`).contains("In Progress");
+    }
 }
 
 class TaskSummary {
@@ -49,7 +84,8 @@ class TaskSummary {
 
         return this;
     }
-}
+
+   }
 
 export const ConversionTaskNames = {
     HandoverWithRegionalDeliveryOfficer: "Handover with regional delivery officer"


### PR DESCRIPTION
This PR includes a work from AI buildathon (experimenting how AI helps in creating cypress tests)

- Added tests for navigating through all the task lists for Conversion project
- Added test for completing the fist Conversion task  - Handover with regional delivery officer
   Checking all the statuses of this task
   Add notes on the page
   Editing notes on the page
   Performance of the page
   Accessibility on the page
   Back link on the page
   
   **Note:** Some of the tests are running fine on Dev env. however as atm Dev is not updated with the latest changes of Conversion task list some of them are failing , which might need bit tweak. However as a skeleton , should work for all the conversion and Transfers task list. 
   
 