### PR TITLE
Fix/223890 cypress antiforgery

### DIFF
--- a/src/Frontend/Dfe.Complete/Startup.cs
+++ b/src/Frontend/Dfe.Complete/Startup.cs
@@ -20,25 +20,19 @@ using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using DfE.CoreLibs.Http.Middlewares.CorrelationId;
 using DfE.CoreLibs.Http.Interfaces;
 using Dfe.Complete.Logging.Middleware;
-using Microsoft.AspNetCore.Mvc;
 using DfE.CoreLibs.Security.Antiforgery;
 using Dfe.Complete.Validators;
 using DfE.CoreLibs.Security.Enums;
-using Dfe.Complete.Application.Extensions;
-using DfE.CoreLibs.Security.Interfaces;
-using Microsoft.AspNetCore.Antiforgery;
 
 namespace Dfe.Complete;
 
 public class Startup
 {
     private readonly TimeSpan _authenticationExpiration;
-    private readonly IWebHostEnvironment _env;
 
-    public Startup(IConfiguration configuration, IWebHostEnvironment env)
+    public Startup(IConfiguration configuration)
     {
         Configuration = configuration;
-        _env = env;
         _authenticationExpiration = TimeSpan.FromMinutes(int.Parse(Configuration["AuthenticationExpirationInMinutes"] ?? "60"));
     }
 

--- a/src/Frontend/Dfe.Complete/Startup.cs
+++ b/src/Frontend/Dfe.Complete/Startup.cs
@@ -25,6 +25,8 @@ using DfE.CoreLibs.Security.Antiforgery;
 using Dfe.Complete.Validators;
 using DfE.CoreLibs.Security.Enums;
 using Dfe.Complete.Application.Extensions;
+using DfE.CoreLibs.Security.Interfaces;
+using Microsoft.AspNetCore.Antiforgery;
 
 namespace Dfe.Complete;
 
@@ -85,8 +87,12 @@ public class Startup
            {
                opts.CheckerGroups =
                [
-                   new() {
-                       TypeNames   = [nameof(HasHeaderKeyExistsInRequestValidator), nameof(CypressRequestChecker)],
+                   new()
+                   {
+                       TypeNames = [
+                           typeof(HasHeaderKeyExistsInRequestValidator).FullName!,
+                           typeof(CypressRequestChecker).FullName!
+                       ],
                        CheckerOperator = CheckerOperator.Or
                    }
                ];

--- a/src/Frontend/Dfe.Complete/Startup.cs
+++ b/src/Frontend/Dfe.Complete/Startup.cs
@@ -66,11 +66,6 @@ public class Startup
         services
             .AddRazorPages(options =>
             {
-                if (_env.IsTest())
-                {
-                    options.Conventions.ConfigureFilter(new IgnoreAntiforgeryTokenAttribute());
-                }
-
                 options.Conventions.AuthorizeFolder("/");
                 options.Conventions.AddPageRoute("/Projects/EditProjectNote", "projects/{projectId}/notes/edit");
             })

--- a/src/Tests/Dfe.Complete.CypressTests/cypress/auth/authenticationInterceptor.ts
+++ b/src/Tests/Dfe.Complete.CypressTests/cypress/auth/authenticationInterceptor.ts
@@ -14,6 +14,7 @@ export class AuthenticationInterceptor {
                     ...req.headers,
                     Authorization: `Bearer ${Cypress.env(EnvAuthKey)}`,
                     "x-user-context-name": user.username, // must be present, but not used
+                    "x-user-context-id": user.id, // must be present for antiforgery claims
                     "x-user-ad-id": user.adId,
                     "x-cypress-user": userType,
                 };

--- a/src/Tests/Dfe.Complete.Tests/Authorization/CypressAuthenticationRegistrationTests.cs
+++ b/src/Tests/Dfe.Complete.Tests/Authorization/CypressAuthenticationRegistrationTests.cs
@@ -115,10 +115,7 @@ namespace Dfe.Complete.Tests.Authorization
 
             services.AddSingleton<IConfiguration>(configuration);
 
-            var mockEnv = new Mock<IWebHostEnvironment>();
-            mockEnv.Setup(env => env.EnvironmentName).Returns("Development");
-            services.AddSingleton<IHostEnvironment>(mockEnv.Object);
-            var startup = new Startup(configuration, mockEnv.Object);
+            var startup = new Startup(configuration);
             startup.ConfigureServices(services);
 
             var serviceProvider = services.BuildServiceProvider();

--- a/src/Tests/Dfe.Complete.Tests/StartupTests.cs
+++ b/src/Tests/Dfe.Complete.Tests/StartupTests.cs
@@ -7,12 +7,10 @@ using DfE.CoreLibs.Security.Enums;
 using DfE.CoreLibs.Security.Interfaces;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
-using Moq;
 
 namespace Dfe.Complete.Tests;
 
@@ -31,8 +29,7 @@ public sealed class StartupDataProtectionTests : IDisposable
     {
         // Arrange
         IConfiguration cfg = BuildConfiguration(_tempDpTargetPath, keyVaultKey: string.Empty);
-        var env = BuildEnvironment();
-        var startup = new Startup(cfg, env);
+        var startup = new Startup(cfg);
         var services = new ServiceCollection();
 
         // Act
@@ -50,8 +47,7 @@ public sealed class StartupDataProtectionTests : IDisposable
         // Arrange
         var fakeKeyVaultUri = "https://contoso.vault.azure.net/keys/dp-unit-test/0000000000000000";
         IConfiguration cfg = BuildConfiguration(_tempDpTargetPath, fakeKeyVaultUri);
-        var env = BuildEnvironment();
-        var startup = new Startup(cfg, env);
+        var startup = new Startup(cfg);
         var services = new ServiceCollection();
 
         // Act
@@ -67,8 +63,7 @@ public sealed class StartupDataProtectionTests : IDisposable
     {
         // Arrange
         IConfiguration cfg = BuildConfiguration(_tempDpTargetPath, keyVaultKey: string.Empty);
-        var env = BuildEnvironment();
-        var startup = new Startup(cfg, env);
+        var startup = new Startup(cfg);
         var services = new ServiceCollection();
 
         // Act

--- a/src/Tests/Dfe.Complete.Tests/StartupTests.cs
+++ b/src/Tests/Dfe.Complete.Tests/StartupTests.cs
@@ -42,7 +42,6 @@ public sealed class StartupDataProtectionTests : IDisposable
         // Assert
         Assert.NotNull(sp.GetService<IDataProtectionProvider>());
         Assert.True(Directory.Exists(_tempDpTargetPath));
-
     }
 
     [Fact]
@@ -81,13 +80,18 @@ public sealed class StartupDataProtectionTests : IDisposable
         var configuredOptions = sp.GetRequiredService<IOptions<CustomAwareAntiForgeryOptions>>().Value;
         Assert.NotNull(configuredOptions.CheckerGroups);
 
-        Assert.Contains(services, d => d.ServiceType == typeof(ICustomRequestChecker) && d.ImplementationType == typeof(CypressRequestChecker));
-        Assert.Contains(services, d => d.ServiceType == typeof(ICustomRequestChecker) && d.ImplementationType == typeof(HasHeaderKeyExistsInRequestValidator));
+        Assert.Contains(services,
+            d => d.ServiceType == typeof(ICustomRequestChecker) &&
+                 d.ImplementationType == typeof(CypressRequestChecker));
+        Assert.Contains(services,
+            d => d.ServiceType == typeof(ICustomRequestChecker) &&
+                 d.ImplementationType == typeof(HasHeaderKeyExistsInRequestValidator));
 
         Assert.Single(configuredOptions.CheckerGroups);
         Assert.Equal(2, configuredOptions.CheckerGroups.First().TypeNames.Length);
-        Assert.Equal(nameof(HasHeaderKeyExistsInRequestValidator), configuredOptions.CheckerGroups[0].TypeNames[0]);
-        Assert.Equal(nameof(CypressRequestChecker), configuredOptions.CheckerGroups[0].TypeNames[1]);
+        Assert.Equal(typeof(HasHeaderKeyExistsInRequestValidator).FullName,
+            configuredOptions.CheckerGroups[0].TypeNames[0]);
+        Assert.Equal(typeof(CypressRequestChecker).FullName, configuredOptions.CheckerGroups[0].TypeNames[1]);
         Assert.Equal(CheckerOperator.Or, configuredOptions.CheckerGroups[0].CheckerOperator);
     }
 
@@ -115,8 +119,8 @@ public sealed class StartupDataProtectionTests : IDisposable
     private static void InvokeSetupDataProtection(Startup startup, IServiceCollection services)
     {
         MethodInfo? mi = typeof(Startup).GetMethod(
-                            "SetupDataProtection",
-                            BindingFlags.Instance | BindingFlags.NonPublic);
+            "SetupDataProtection",
+            BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(mi);
         mi.Invoke(startup, [services]);
     }
@@ -133,7 +137,12 @@ public sealed class StartupDataProtectionTests : IDisposable
 
     public void Dispose()
     {
-        try { Directory.Delete(_tempDpTargetPath, recursive: true); }
-        catch { }
+        try
+        {
+            Directory.Delete(_tempDpTargetPath, recursive: true);
+        }
+        catch
+        {
+        }
     }
 }

--- a/src/Tests/Dfe.Complete.Tests/StartupTests.cs
+++ b/src/Tests/Dfe.Complete.Tests/StartupTests.cs
@@ -80,8 +80,8 @@ public sealed class StartupDataProtectionTests : IDisposable
 
         Assert.Single(configuredOptions.CheckerGroups);
         Assert.Equal(2, configuredOptions.CheckerGroups.First().TypeNames.Length);
-        Assert.Equal(nameof(HasHeaderKeyExistsInRequestValidator), configuredOptions.CheckerGroups[0].TypeNames[0]);
-        Assert.Equal(nameof(CypressRequestChecker), configuredOptions.CheckerGroups[0].TypeNames[1]);
+        Assert.Equal(typeof(HasHeaderKeyExistsInRequestValidator).FullName, configuredOptions.CheckerGroups[0].TypeNames[0]);
+        Assert.Equal(typeof(CypressRequestChecker).FullName, configuredOptions.CheckerGroups[0].TypeNames[1]);
         Assert.Equal(CheckerOperator.Or, configuredOptions.CheckerGroups[0].CheckerOperator);
     }
 

--- a/src/Tests/Dfe.Complete.Tests/StartupTests.cs
+++ b/src/Tests/Dfe.Complete.Tests/StartupTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Reflection;
 using Dfe.Complete.Validators;
 using DfE.CoreLibs.Security.Antiforgery;
@@ -39,6 +38,7 @@ public sealed class StartupDataProtectionTests : IDisposable
         // Assert
         Assert.NotNull(sp.GetService<IDataProtectionProvider>());
         Assert.True(Directory.Exists(_tempDpTargetPath));
+
     }
 
     [Fact]
@@ -75,18 +75,13 @@ public sealed class StartupDataProtectionTests : IDisposable
         var configuredOptions = sp.GetRequiredService<IOptions<CustomAwareAntiForgeryOptions>>().Value;
         Assert.NotNull(configuredOptions.CheckerGroups);
 
-        Assert.Contains(services,
-            d => d.ServiceType == typeof(ICustomRequestChecker) &&
-                 d.ImplementationType == typeof(CypressRequestChecker));
-        Assert.Contains(services,
-            d => d.ServiceType == typeof(ICustomRequestChecker) &&
-                 d.ImplementationType == typeof(HasHeaderKeyExistsInRequestValidator));
+        Assert.Contains(services, d => d.ServiceType == typeof(ICustomRequestChecker) && d.ImplementationType == typeof(CypressRequestChecker));
+        Assert.Contains(services, d => d.ServiceType == typeof(ICustomRequestChecker) && d.ImplementationType == typeof(HasHeaderKeyExistsInRequestValidator));
 
         Assert.Single(configuredOptions.CheckerGroups);
         Assert.Equal(2, configuredOptions.CheckerGroups.First().TypeNames.Length);
-        Assert.Equal(typeof(HasHeaderKeyExistsInRequestValidator).FullName,
-            configuredOptions.CheckerGroups[0].TypeNames[0]);
-        Assert.Equal(typeof(CypressRequestChecker).FullName, configuredOptions.CheckerGroups[0].TypeNames[1]);
+        Assert.Equal(nameof(HasHeaderKeyExistsInRequestValidator), configuredOptions.CheckerGroups[0].TypeNames[0]);
+        Assert.Equal(nameof(CypressRequestChecker), configuredOptions.CheckerGroups[0].TypeNames[1]);
         Assert.Equal(CheckerOperator.Or, configuredOptions.CheckerGroups[0].CheckerOperator);
     }
 
@@ -114,8 +109,8 @@ public sealed class StartupDataProtectionTests : IDisposable
     private static void InvokeSetupDataProtection(Startup startup, IServiceCollection services)
     {
         MethodInfo? mi = typeof(Startup).GetMethod(
-            "SetupDataProtection",
-            BindingFlags.Instance | BindingFlags.NonPublic);
+                            "SetupDataProtection",
+                            BindingFlags.Instance | BindingFlags.NonPublic);
         Assert.NotNull(mi);
         mi.Invoke(startup, [services]);
     }
@@ -132,12 +127,7 @@ public sealed class StartupDataProtectionTests : IDisposable
 
     public void Dispose()
     {
-        try
-        {
-            Directory.Delete(_tempDpTargetPath, recursive: true);
-        }
-        catch
-        {
-        }
+        try { Directory.Delete(_tempDpTargetPath, recursive: true); }
+        catch { }
     }
 }


### PR DESCRIPTION
- antiforgery fix
- re-enable antiforgery in test env
- fix type resolution issue for antiforgery - adds stacktrace (dev)

The problem was that the cypress tests CypressAuthenticationHandler in corelibs security was generating a new guid for the nameidentifier claim for each request. For the POST requests, the claims need to match for the GET & POST request.

CypressAuthenticationHandler allows the nameidentifier claim to be set from the headers by providing it as the "x-user-context-id"  header.