### PR TITLE
Prevent clearing of all temp data

### DIFF
--- a/src/Frontend/Dfe.Complete/Pages/Public/Cookies.cshtml.cs
+++ b/src/Frontend/Dfe.Complete/Pages/Public/Cookies.cshtml.cs
@@ -80,7 +80,15 @@ namespace Dfe.Complete.Pages.Public
 				}
 				else
 				{
-					TempData.Clear();
+                    if(TempData["PreferencesSet"] != null)
+					{ 
+						TempData["PreferencesSet"] = null;
+                    }
+
+                    if(TempData["IsRubyRequest"] != null)
+					{
+						TempData["IsRubyRequest"] = null;
+                    }
 				}
 			}
 

--- a/src/Frontend/Dfe.Complete/Pages/Shared/_SetCookiesPreferenceBanner.cshtml
+++ b/src/Frontend/Dfe.Complete/Pages/Shared/_SetCookiesPreferenceBanner.cshtml
@@ -1,6 +1,16 @@
 ﻿@{
     var hasCookiesSet = TempData["PreferencesSet"];
-    TempData.Clear();
+
+    @if (TempData["PreferencesSet"] != null)
+    {
+        TempData["PreferencesSet"] = null;
+    }
+
+    @if (TempData["IsRubyRequest"] != null)
+    {
+        TempData["IsRubyRequest"] = null;
+    }
+    
 }
 
 @if (hasCookiesSet != null)


### PR DESCRIPTION
Cleared PreferencesSet and IsRubyRequest tempdata instead of clearing all temp data in  setcookie banner partial page and  cookies page behind