### PR TITLE
236305 - Supplemental funding agreement - transfer - incorrect options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Security in case of vulnerabilities.
 
 ### Fixed
 - update "Give feedback about service" to use correct link
+- update "Task - Supplemental funding agreement - transfer - incorrect options"
+
 
 See the [full commit history](https://github.com/DFE-Digital/complete-conversions-transfers-changes/compare/production-2025-09-09.731...main) for everything awaiting release
 

--- a/src/Frontend/Dfe.Complete/Pages/Projects/TaskList/Tasks/SupplementalFundingAgreementTask/SupplementalFundingAgreementTask.cshtml
+++ b/src/Frontend/Dfe.Complete/Pages/Projects/TaskList/Tasks/SupplementalFundingAgreementTask/SupplementalFundingAgreementTask.cshtml
@@ -47,9 +47,12 @@
                 <govuk-checkboxes-item id="cleared" asp-for="@Model.Cleared" value="true" name="cleared" checked="@Model.Cleared">
                     <b>Cleared</b>
                 </govuk-checkboxes-item>
-                <govuk-checkboxes-item id="signed" asp-for="@Model.Signed" value="true" name="signed" checked="@Model.Signed">
-                    <b>Signed by school or trust</b>
-                </govuk-checkboxes-item>
+                @if (Model.Project.Type == ProjectType.Conversion)
+                {
+                    <govuk-checkboxes-item id="signed" asp-for="@Model.Signed" value="true" name="signed" checked="@Model.Signed">
+                        <b>Signed by school or trust</b>
+                    </govuk-checkboxes-item>
+                }
                 <govuk-checkboxes-item id="saved" asp-for="@Model.Saved" value="true" name="saved" checked="@Model.Saved">
                     <b>Saved in the school's SharePoint folder</b>
                 </govuk-checkboxes-item> 


### PR DESCRIPTION
Fixed the bug, show  check box option "Signed by school or trust" if Project Type is 'Conversion' else hide it