### PR TITLE
add user list view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ See the [full commit history](https://github.com/DFE-Digital/complete-conversion
 - ProjectGroup is created when a project is edited with a new GRN
 - Added Add, Edit and Delete External Contacts for both conversion and transfer projects.
 - Added `Confirm this transfer has authority to proceed` task
+- Add service support - view users table
 
 ### Changed
 - Group reference number links to the group on "About the project"

--- a/src/Api/Dfe.Complete.Api.Client/Generated/Contracts.g.cs
+++ b/src/Api/Dfe.Complete.Api.Client/Generated/Contracts.g.cs
@@ -5211,6 +5211,9 @@ namespace Dfe.Complete.Client.Contracts
         [Newtonsoft.Json.JsonProperty("transferProjectsAssigned", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? TransferProjectsAssigned { get; set; } = default!;
 
+        [Newtonsoft.Json.JsonProperty("latestSession", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.DateTime? LatestSession { get; set; } = default!;
+
         public string ToJson()
         {
 

--- a/src/Api/Dfe.Complete.Api.Client/Generated/swagger.json
+++ b/src/Api/Dfe.Complete.Api.Client/Generated/swagger.json
@@ -7027,6 +7027,11 @@
           "transferProjectsAssigned": {
             "type": "integer",
             "format": "int32"
+          },
+          "latestSession": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
           }
         }
       }

--- a/src/Core/Dfe.Complete.Application/Users/Models/ListAllUsersWithProjectsResultsModel.cs
+++ b/src/Core/Dfe.Complete.Application/Users/Models/ListAllUsersWithProjectsResultsModel.cs
@@ -9,4 +9,5 @@ public record ListAllUsersWithProjectsResultModel(
     string? Email,
     ProjectTeam? Team,
     int ConversionProjectsAssigned,
-    int TransferProjectsAssigned);
+    int TransferProjectsAssigned,
+    DateTime? LatestSession = null);

--- a/src/Core/Dfe.Complete.Application/Users/Queries/ListAllUsers/ListAllUsersWithProjects.cs
+++ b/src/Core/Dfe.Complete.Application/Users/Queries/ListAllUsers/ListAllUsersWithProjects.cs
@@ -45,13 +45,14 @@ public class ListAllUsersWithProjectsHandler(ICompleteRepository<User> users, IL
                     user.Id,
                     user.FullName,
                     user.Email,
-                    user.Team.FromDescriptionValue<ProjectTeam>(),
+                    user.Team == null ? null : user.Team.FromDescriptionValue<ProjectTeam>(),
                     user.ProjectAssignedTos
                         .Where(project => request.State == null || project.State == request.State)
                         .Count(project => project.Type == ProjectType.Conversion),
                     user.ProjectAssignedTos
                         .Where(project => request.State == null || project.State == request.State)
-                        .Count(project => project.Type == ProjectType.Transfer)
+                        .Count(project => project.Type == ProjectType.Transfer),
+                    user.LatestSession
                 ))
                 .ToListAsync(cancellationToken);
 

--- a/src/Frontend/Dfe.Complete/Constants/RouteConstants.cs
+++ b/src/Frontend/Dfe.Complete/Constants/RouteConstants.cs
@@ -131,6 +131,10 @@
         public const string ServiceSupportProjectsWithAcademyUrn = "/projects/service-support/with-academy-urn";
         public const string ServiceSupportAssignAcademyUrn = "/projects/{0}/academy-urn";
         public const string ServiceSupportProjects = "/projects/service-support/without-academy-urn";
+        public const string ServiceSupportUsers = "/service-support/users";
+        public const string ServiceSupportUsersNew = "/service-support/users/new";
+        public const string ServiceSupportUsersEdit = "/service-support/users/{0}/edit";
+
 
         //Local authorities
         public const string ListLocalAuthorities = "/service-support/local-authorities";

--- a/src/Frontend/Dfe.Complete/Pages/Projects/ServiceSupport/Users/ListUsers.cshtml
+++ b/src/Frontend/Dfe.Complete/Pages/Projects/ServiceSupport/Users/ListUsers.cshtml
@@ -1,0 +1,47 @@
+﻿@page "/service-support/users"
+@using Dfe.Complete.Constants
+@using Dfe.Complete.Extensions
+@using Dfe.Complete.Application.Mappers
+@model Dfe.Complete.Pages.Projects.ServiceSupport.Users.ListUsers
+@{
+    Layout = "ServiceSupport/Users/_UsersLayout";
+    ViewData["Title"] = "Users";
+}
+
+<div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">
+        Users
+    </h1>
+    <a data-module="govuk-button" draggable="false" role="button" class="govuk-button"
+        href="@RouteConstants.ServiceSupportUsersNew">Add a new user</a>
+    <table class="govuk-table" name="users_table" aria-label="Users table">
+        <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+                <th class="govuk-table__header" scope="col">Name</th>
+                <th class="govuk-table__header" scope="col">Email</th>
+                <th class="govuk-table__header" scope="col">Team</th>
+                <th class="govuk-table__header" scope="col">Last seen</th>
+                <th class="govuk-table__header" scope="col">Edit user</th>
+            </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+
+            @foreach (var user in Model.Users)
+            {
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__header govuk-table__cell">@user.FullName</td>
+                    <td class="govuk-table__cell">@user.Email</td>
+                    <td class="govuk-table__cell">@(user.Team != null ?
+                                            @ProjectTeamPresentationMapper.Map(user.Team) : "No team")</td>
+                    <td class="govuk-table__cell">@(user.LatestSession != null ?
+                                            ((DateTime)user.LatestSession).ToUkDateTimeWithAmPmString() : "N/A")</td>
+                    <td class="govuk-table__cell">
+                        <a class="govuk-link"
+                            href="@String.Format(RouteConstants.ServiceSupportUsersEdit, user.Id.Value.ToStringOrDefault())">Edit
+                            user</a>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+</div>

--- a/src/Frontend/Dfe.Complete/Pages/Projects/ServiceSupport/Users/ListUsers.cshtml.cs
+++ b/src/Frontend/Dfe.Complete/Pages/Projects/ServiceSupport/Users/ListUsers.cshtml.cs
@@ -1,0 +1,23 @@
+
+using Dfe.Complete.Application.Users.Models;
+using Dfe.Complete.Application.Users.Queries.ListAllUsers;
+using Dfe.Complete.Constants;
+using Dfe.Complete.Pages.Pagination;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Dfe.Complete.Pages.Projects.ServiceSupport.Users;
+
+public class ListUsers(ISender sender) : ServiceSupportModel(UsersNavigation)
+{
+    public List<ListAllUsersWithProjectsResultModel> Users { get; set; } = default!;
+    public async Task<IActionResult> OnGetAsync()
+    {
+        var usersResponse = await sender.Send(new ListAllUsersWithProjectsQuery(null, null, false) { Page = PageNumber - 1, Count = PageSize });
+        Users = usersResponse.Value ?? [];
+
+        Pagination = new PaginationModel(RouteConstants.ServiceSupportUsers, PageNumber, usersResponse.ItemCount, PageSize);
+        var hasPageFound = HasPageFound(Pagination.IsOutOfRangePage, Pagination.TotalPages);
+        return hasPageFound ?? Page();
+    }
+}

--- a/src/Frontend/Dfe.Complete/Pages/Projects/ServiceSupport/Users/_UsersLayout.cshtml
+++ b/src/Frontend/Dfe.Complete/Pages/Projects/ServiceSupport/Users/_UsersLayout.cshtml
@@ -1,0 +1,8 @@
+﻿@model Dfe.Complete.Pages.Projects.ServiceSupport.Users.ListUsers
+@{
+    Layout = "ServiceSupport/_ServiceSupportLayout";
+}
+
+<div class="govuk-grid-row">
+    @RenderBody()
+</div>

--- a/src/Tests/Dfe.Complete.Application.Tests/QueryHandlers/User/ListAllUsersWithProjectsHandlerTest.cs
+++ b/src/Tests/Dfe.Complete.Application.Tests/QueryHandlers/User/ListAllUsersWithProjectsHandlerTest.cs
@@ -42,7 +42,8 @@ public class ListAllUsersWithProjectsHandlerTest
             user.Email,
             user.Team.FromDescriptionValue<ProjectTeam>(),
             user.ProjectAssignedTos.Count(project => project.Type == ProjectType.Conversion),
-            user.ProjectAssignedTos.Count(project => project.Type == ProjectType.Transfer)
+            user.ProjectAssignedTos.Count(project => project.Type == ProjectType.Transfer),
+            user.LatestSession
         )).ToList();
         var userQueryable = users.BuildMock();
 
@@ -122,7 +123,8 @@ public class ListAllUsersWithProjectsHandlerTest
             user.Email,
             user.Team.FromDescriptionValue<ProjectTeam>(),
             user.ProjectAssignedTos.Count(project => project.Type == ProjectType.Conversion),
-            user.ProjectAssignedTos.Count(project => project.Type == ProjectType.Transfer)
+            user.ProjectAssignedTos.Count(project => project.Type == ProjectType.Transfer),
+            user.LatestSession
         )).Skip(10).Take(5).ToList();
         var userQueryable = users.BuildMock();
 
@@ -170,7 +172,8 @@ public class ListAllUsersWithProjectsHandlerTest
             user.Email,
             user.Team.FromDescriptionValue<ProjectTeam>(),
             user.ProjectAssignedTos.Where(project => project.State == ProjectState.Active).Count(project => project.Type == ProjectType.Conversion),
-            user.ProjectAssignedTos.Where(project => project.State == ProjectState.Active).Count(project => project.Type == ProjectType.Transfer)
+            user.ProjectAssignedTos.Where(project => project.State == ProjectState.Active).Count(project => project.Type == ProjectType.Transfer),
+            user.LatestSession
         )).ToList();
         var userQueryable = users.BuildMock();
 

--- a/src/Tests/Dfe.Complete.Tests/SecurityTests/ExpectedSecurityConfig.json
+++ b/src/Tests/Dfe.Complete.Tests/SecurityTests/ExpectedSecurityConfig.json
@@ -129,6 +129,10 @@
       "ExpectedSecurity": "Authorize: Policy=ManageLocalAuthorities"
     },
     {
+      "Route": "Projects/ServiceSupport/Users/ListUsers",
+      "ExpectedSecurity": "Authorize: Policy=CanViewServiceSupport"
+    },
+    {
       "Route": "Projects/List/HandoverProjects/HandoverProjectCheck",
       "ExpectedSecurity": "Authorize: Policy=CanViewAllProjectsHandover"
     },


### PR DESCRIPTION
## Ticket

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_backlogs/backlog/Dot%20Net/Features?workitem=237868

## Description

Most of the description is on ticket.

Show list of users at /service-support/users
Auth = Service Support user
Add broken "Add new user" button (for front door consistency)
Add broken "Edit user" button (for front door consistency)

Differencece:
 - drop active/inactive users
 - drop "Team lead" column
 - Timestamp - reads DB time, some of these will be 1 hour different