### PR TITLE
resolve cypress tests

### DIFF
--- a/src/Core/Dfe.Complete.Application/Validation/SignificantDateValidator.cs
+++ b/src/Core/Dfe.Complete.Application/Validation/SignificantDateValidator.cs
@@ -77,7 +77,7 @@ public class SignificantDateValidator : ISignificantDateValidator
     {
         if (payrollDeadline.HasValue && payrollDeadline.Value.ToDateTime(new TimeOnly()) < DateTime.Today)
         {
-            return ValidationResult.Error("The payroll deadline must be in the future.");
+            return ValidationResult.Error("Payroll deadline must be in the future.");
         }
 
         return ValidationResult.Success();
@@ -87,7 +87,7 @@ public class SignificantDateValidator : ISignificantDateValidator
     {
         if (payrollDeadline.HasValue && significantDate.HasValue && payrollDeadline >= significantDate.Value)
         {
-            return ValidationResult.Error("The payroll deadline must be before the significant date.");
+            return ValidationResult.Error("Payroll deadline must be before the significant date.");
         }
 
         return ValidationResult.Success();

--- a/src/Tests/Dfe.Complete.Application.Tests/Validators/SignificantDateValidatorTests.cs
+++ b/src/Tests/Dfe.Complete.Application.Tests/Validators/SignificantDateValidatorTests.cs
@@ -276,7 +276,7 @@ namespace Dfe.Complete.Application.Tests.Validators
 
             // Assert
             Assert.False(result.IsValid);
-            Assert.Equal("The payroll deadline must be in the future.", result.ErrorMessage);
+            Assert.Equal("Payroll deadline must be in the future.", result.ErrorMessage);
         }
 
         [Fact]
@@ -292,7 +292,7 @@ namespace Dfe.Complete.Application.Tests.Validators
 
             // Assert
             Assert.False(result.IsValid);
-            Assert.Equal("The payroll deadline must be before the significant date.", result.ErrorMessage);
+            Assert.Equal("Payroll deadline must be before the significant date.", result.ErrorMessage);
         }
 
         [Fact]

--- a/src/Tests/Dfe.Complete.CypressTests/cypress/e2e/conversion-tasks/group-one/la-confirms-payroll-deadline.cy.ts
+++ b/src/Tests/Dfe.Complete.CypressTests/cypress/e2e/conversion-tasks/group-one/la-confirms-payroll-deadline.cy.ts
@@ -4,10 +4,17 @@ import taskPage from "cypress/pages/projects/tasks/taskPage";
 import { Logger } from "cypress/common/logger";
 import { ConversionTasksGroupOneSetup } from "cypress/support/conversionTasksSetup";
 import validationComponent from "cypress/pages/validationComponent";
-import stakeholderKickOffTaskPage from "cypress/pages/projects/tasks/stakeholderKickOffTaskPage";
+import taskHelperConversions from "cypress/api/taskHelperConversions";
+import { getSignificantDateString } from "cypress/support/formatDate";
 
 const taskPath = "la_confirms_payroll_deadline";
-const stakeholderKickOffTaskPath = "stakeholder_kick_off";
+
+const today = new Date();
+const dayTomorrow = String(today.getDate() + 1);
+const month = String(today.getMonth() + 1);
+const year = String(today.getFullYear());
+const yearTwoYearsFromNow = String(today.getFullYear() + 2);
+const significantDateNextYear = getSignificantDateString(12);
 
 describe("Conversion tasks - LA confirms payroll deadline", () => {
     let setup: ReturnType<typeof ConversionTasksGroupOneSetup.getSetup>;
@@ -20,10 +27,7 @@ describe("Conversion tasks - LA confirms payroll deadline", () => {
                 expect(setup.projectId, 'projectId should be set').to.not.be.empty;
             });
         }).then(() => {
-            cy.login();
-            cy.visit(`projects/${setup.projectId}/tasks/${stakeholderKickOffTaskPath}`);
-            stakeholderKickOffTaskPage.enterSignificantDate(1, new Date().getFullYear() + 1).saveAndReturn();
-            cy.visit(`projects/${setup.projectId}/tasks/${taskPath}`);
+            taskHelperConversions.updateExternalStakeholderKickOff(setup.projectId, "completed", significantDateNextYear);
         });
     });
 
@@ -32,11 +36,6 @@ describe("Conversion tasks - LA confirms payroll deadline", () => {
     });
 
     it("should be able to input a valid future date before the significant date", () => {
-        const today = new Date();
-        const dayTomorrow = String(today.getDate() + 1);
-        const month = String(today.getMonth() + 1);
-        const year = String(today.getFullYear());
-
         Logger.log("Input the date and save");
         taskPage.enterDate(dayTomorrow, month, year, "payroll-deadline").saveAndReturn();
         taskListPage
@@ -51,7 +50,7 @@ describe("Conversion tasks - LA confirms payroll deadline", () => {
         taskPage.hasDate("", "", "", "payroll-deadline");
     });
 
-    it.only("should show validation errors", () => {
+    it("should show validation errors", () => {
         Logger.log("Try to input a past date");
         taskPage
             .enterDate("15", "6", "2020", "payroll-deadline")
@@ -61,7 +60,7 @@ describe("Conversion tasks - LA confirms payroll deadline", () => {
 
         Logger.log("Try to input a date after the significant date");
         taskPage
-            .enterDate("15", "6", String(new Date().getFullYear() + 10), "payroll-deadline")
+            .enterDate("15", "6", yearTwoYearsFromNow, "payroll-deadline")
             .saveAndReturn()
 
         validationComponent.hasLinkedValidationError("Payroll deadline must be before the significant date");

--- a/src/Tests/Dfe.Complete.CypressTests/cypress/e2e/conversion-tasks/group-one/la-confirms-payroll-deadline.cy.ts
+++ b/src/Tests/Dfe.Complete.CypressTests/cypress/e2e/conversion-tasks/group-one/la-confirms-payroll-deadline.cy.ts
@@ -3,15 +3,28 @@ import taskListPage from "cypress/pages/projects/tasks/taskListPage";
 import taskPage from "cypress/pages/projects/tasks/taskPage";
 import { Logger } from "cypress/common/logger";
 import { ConversionTasksGroupOneSetup } from "cypress/support/conversionTasksSetup";
+import validationComponent from "cypress/pages/validationComponent";
+import stakeholderKickOffTaskPage from "cypress/pages/projects/tasks/stakeholderKickOffTaskPage";
 
 const taskPath = "la_confirms_payroll_deadline";
+const stakeholderKickOffTaskPath = "stakeholder_kick_off";
 
 describe("Conversion tasks - LA confirms payroll deadline", () => {
     let setup: ReturnType<typeof ConversionTasksGroupOneSetup.getSetup>;
-
     before(() => {
-        ConversionTasksGroupOneSetup.setupProjectsWithoutTaskId();
-        setup = ConversionTasksGroupOneSetup.getSetup();
+        cy.then(() => {
+            ConversionTasksGroupOneSetup.setupProjectsWithoutTaskId();
+            setup = ConversionTasksGroupOneSetup.getSetup();
+        }).then(() => {
+            return cy.wrap(null).should(() => {
+                expect(setup.projectId, 'projectId should be set').to.not.be.empty;
+            });
+        }).then(() => {
+            cy.login();
+            cy.visit(`projects/${setup.projectId}/tasks/${stakeholderKickOffTaskPath}`);
+            stakeholderKickOffTaskPage.enterSignificantDate(1, new Date().getFullYear() + 1).saveAndReturn();
+            cy.visit(`projects/${setup.projectId}/tasks/${taskPath}`);
+        });
     });
 
     beforeEach(() => {
@@ -38,24 +51,27 @@ describe("Conversion tasks - LA confirms payroll deadline", () => {
         taskPage.hasDate("", "", "", "payroll-deadline");
     });
 
-    it("should show validation errors", () => {
+    it.only("should show validation errors", () => {
         Logger.log("Try to input a past date");
         taskPage
             .enterDate("15", "6", "2020", "payroll-deadline")
             .saveAndReturn()
-            .hasLinkedValidationErrorForField('payroll-deadline.Day', "Payroll deadline must be in the future");
+
+        validationComponent.hasLinkedValidationError("Payroll deadline must be in the future.");
 
         Logger.log("Try to input a date after the significant date");
         taskPage
             .enterDate("15", "6", String(new Date().getFullYear() + 10), "payroll-deadline")
             .saveAndReturn()
-            .hasLinkedValidationErrorForField('payroll-deadline.Day', "Payroll deadline must be before the significant date");
+
+        validationComponent.hasLinkedValidationError("Payroll deadline must be before the significant date");
 
         Logger.log("Try to input an invalid date");
         taskPage
             .enterDate("15", "16", "2020", "payroll-deadline")
             .saveAndReturn()
-            .hasLinkedValidationErrorForField('payroll-deadline.Day', "Payroll deadline must be a real date");
+
+        validationComponent.hasLinkedValidationError("Payroll deadline must be a real date");
     });
 
     it("Should NOT see the 'save and return' button for another user's project", () => {


### PR DESCRIPTION
Issues resolved.

1. The validation wording didn't match so it was never going to pass
2. `'.'` in css gets picks up as ID AND a class name. #payroll-deadline.Day is therefore seen as ID: payroll-deadline, class: Day. I've used an alternative assertion (validationComponent) - alternatively, we could just add the split['.'] logic to the other error asserter
3. I then found that one of the tests SHOULD fail because the LA payroll date needs to be before the confirmed significant date. If the date is provisional, it doesn't matter when the la payroll date is. I wrote the cypress test before we confirmed that logic
4. So I updated the date using PATCH /SignificantDate, there's a projectApi helper for this in cypress suite already. However, that just updates the date - it doesn't actually change it's provisional status, so that didn't help. So instead, I physically visit the external stakeholder kickoff task and add a date - it's the only command that makes the date non-provisional...

