### PR TITLE
revert mediatr to pre-license

### DIFF
--- a/src/Core/Dfe.Complete.Domain/Dfe.Complete.Domain.csproj
+++ b/src/Core/Dfe.Complete.Domain/Dfe.Complete.Domain.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="GovUK.Dfe.CoreLibs.Caching" Version="1.0.13" />
     <PackageReference Include="FluentValidation" Version="12.0.0" />
-    <PackageReference Include="MediatR" Version="13.0.0" />
+    <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 


### PR DESCRIPTION
mega pr. revert mediatr version. 13 requires a license. it was on 12.4.1 before and worked fine.

reverts this
https://github.com/DFE-Digital/complete-conversions-transfers-changes/commit/73db78e21cd99f4d39bc0cdafc3a1cfd722909a9#diff-5a1ced76d2dd942374a61038ffae1ca18a92f0452c4e15f9c6b7cd29ce369c25