### PR TITLE
Downgrade logging for maintenance banner with past date to warning

### DIFF
--- a/src/Frontend/Dfe.Complete/Services/MaintenanceBannerService.cs
+++ b/src/Frontend/Dfe.Complete/Services/MaintenanceBannerService.cs
@@ -42,7 +42,7 @@ namespace Dfe.Complete.Services
                 // Validate maintenance end is not in the past (if provided)
                 if (_options.MaintenanceEnd.HasValue && _options.MaintenanceEnd.Value < now)
                 {
-                    _logger.LogError("Maintenance banner configuration error: MaintenanceEnd ({MaintenanceEnd}) is in the past", _options.MaintenanceEnd.Value);
+                    _logger.LogWarning("Maintenance banner configuration error: MaintenanceEnd ({MaintenanceEnd}) is in the past", _options.MaintenanceEnd.Value);
                     return false;
                 }
 

--- a/src/Tests/Dfe.Complete.Tests/Services/MaintenanceBannerServiceTests.cs
+++ b/src/Tests/Dfe.Complete.Tests/Services/MaintenanceBannerServiceTests.cs
@@ -99,7 +99,7 @@ public class MaintenanceBannerServiceTests
     }
 
     [Fact]
-    public void ShouldShowBanner_WhenMaintenanceEndInPast_ShouldReturnFalseAndLogError()
+    public void ShouldShowBanner_WhenMaintenanceEndInPast_ShouldReturnFalseAndLogWarning()
     {
         // Arrange
         _mockEnvironment.Setup(x => x.EnvironmentName).Returns(Environments.Production);
@@ -119,7 +119,7 @@ public class MaintenanceBannerServiceTests
         result.Should().BeFalse();
         _mockLogger.Verify(
             x => x.Log(
-                LogLevel.Error,
+                LogLevel.Warning,
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("MaintenanceEnd") && v.ToString()!.Contains("is in the past")),
                 It.IsAny<Exception>(),


### PR DESCRIPTION
Lowers the logging level for Maintenance banners with a historic date set from Error to Warning.

Reduces false positive Error counts in Azure as a result.